### PR TITLE
docker: Allow chown commands to fail

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,8 +22,8 @@ if [[ ! -r "$CONFIG_FILE" ]]; then
 fi
 
 echo "> Setup permissions.."
-find /app \! -user "$UID" -exec chown "$UID:$GID" '{}' +
-find /data \! -user "$UID" -exec chown "$UID:$GID" '{}' +
+find /app \! -user "$UID" -exec chown "$UID:$GID" '{}' + || true
+find /data \! -user "$UID" -exec chown "$UID:$GID" '{}' +  || true
 
 
 echo "> Starting lldap.."


### PR DESCRIPTION
chown may not be allowed in containers with restricted security contexts. See https://github.com/truecharts/charts/pull/7779.