### PR TITLE
server: Improve the error message in case of duplicate emails

### DIFF
--- a/docs/migration_guides/v0.5.md
+++ b/docs/migration_guides/v0.5.md
@@ -1,0 +1,58 @@
+# Migration from 0.4 to 0.5
+
+Welcome! If you're here, it's probably that the migration from 0.4.x to 0.5
+didn't go smoothly for you. Don't worry, we can fix that.
+
+## Multiple users with the same email
+
+This is the most common case. You can see in the LLDAP logs that there are
+several users with the same email, and they are listed.
+
+This is not allowed anymore in v0.5, to prevent a user from setting their email
+to someone else's email and gaining access to systems that identify by email.
+
+The problem is that you currently have several users with the same email, so the
+constraint cannot be enforced.
+
+### Step 1: Take a note of the users with duplicate emails
+
+In the LLDAP logs when you tried to start v0.5+, you'll see some warnings with
+the list of users with the same emails. Take note of them.
+
+### Step 2: Downgrade to v0.4.3
+
+If using docker, switch to the `lldap/lldap:v0.4.3` image. Alternatively, grab
+the binaries at https://github.com/lldap/lldap/releases/tag/v0.4.3.
+
+This downgrade is safe and supported.
+
+### Step 3: Remove duplicate emails
+
+Restart LLDAP with the v0.4.3 version, and using your notes from step 1, change
+the email of users with duplicate emails to make sure that each email is unique.
+
+### Step 4: Upgrade again
+
+You can now revert to the initial version.
+
+## Multiple users/groups with the same UUID
+
+This should be extremely rare. In this case, you'll need to find which users
+have the same UUID, revert to v0.4.3 to be able to apply the changes, and delete
+one of the duplicates.
+
+## FAQ
+
+### What if I want several users to be controlled by the same email?
+
+You can use plus codes to set "the same" email to several users, while ensuring
+that they can't identify as each other. For instance:
+
+ - Admin: `admin@example.com`
+ - Read-only admin: `admin+readonly@example.com`
+ - Jellyfin admin: `admin+jellyfin@example.com`
+
+### I'm upgrading to a higher version than v0.5.
+
+This guide is still relevant: you can use whatever later version in place of
+v0.5. You'll still need to revert to v0.4.3 to apply the changes.

--- a/server/src/domain/sql_migrations.rs
+++ b/server/src/domain/sql_migrations.rs
@@ -574,6 +574,7 @@ pub async fn migrate_from_version(
         std::cmp::Ordering::Equal => return Ok(()),
         std::cmp::Ordering::Greater => anyhow::bail!("DB version downgrading is not supported"),
     }
+    info!("Upgrading DB schema from version {}", version.0);
     let migrations = [
         to_sync!(migrate_to_v2),
         to_sync!(migrate_to_v3),
@@ -581,7 +582,7 @@ pub async fn migrate_from_version(
     ];
     for migration in 2..=4 {
         if version < SchemaVersion(migration) && SchemaVersion(migration) <= last_version {
-            info!("Upgrading DB schema from {} to {}", version.0, migration);
+            info!("Upgrading DB schema to version {}", migration);
             migrations[(migration - 2) as usize](pool).await?;
         }
     }


### PR DESCRIPTION
Example error message, from the test:

```
2023-04-14T09:44:38.905177Z  INFO lldap::domain::sql_migrations: Upgrading DB schema from version 1
2023-04-14T09:44:38.905208Z  INFO lldap::domain::sql_migrations: Upgrading DB schema to version 2
2023-04-14T09:44:38.910783Z  INFO lldap::domain::sql_migrations: Upgrading DB schema to version 3
2023-04-14T09:44:38.924604Z  INFO lldap::domain::sql_migrations: Upgrading DB schema to version 4
2023-04-14T09:40:08.738013Z  WARN lldap::domain::sql_migrations: Found several users with the same email:
2023-04-14T09:40:08.738613Z  WARN lldap::domain::sql_migrations: Email: bob@bob.com
2023-04-14T09:40:08.738642Z  WARN lldap::domain::sql_migrations:     User: bob
2023-04-14T09:40:08.738659Z  WARN lldap::domain::sql_migrations:     User: bob2
2023-04-14T09:40:08.738703Z ERROR lldap::domain::sql_tables::tests: while enforcing unicity on emails (2 users have the same email).

See https://github.com/lldap/lldap/blob/main/docs/migration_guides/v0.5.md for details.


```