### PR TITLE
correct env var names in docker template toml

### DIFF
--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -95,13 +95,13 @@ database_url = "sqlite:///data/users.db?mode=rwc"
 ## Randomly generated on first run if it doesn't exist.
 ## Alternatively, you can use key_seed to override this instead of relying on
 ## a file.
-## Env variable: LLDAP_SERVER_KEY_FILE
+## Env variable: LLDAP_KEY_FILE
 key_file = "/data/private_key"
 
 ## Seed to generate the server private key, see key_file above.
 ## This can be any random string, the recommendation is that it's at least 12
 ## characters long.
-## Env variable: LLDAP_SERVER_KEY_SEED
+## Env variable: LLDAP_KEY_SEED
 #key_seed = "RanD0m STR1ng"
 
 ## Ignored attributes.


### PR DESCRIPTION
found out about `LLDAP_KEY_FILE` by trial and error, figured `LLDAP_KEY_SEED` by inference