### PR TITLE
github: enable armv7 musl build

### DIFF
--- a/.github/workflows/Dockerfile.ci.alpine
+++ b/.github/workflows/Dockerfile.ci.alpine
@@ -32,9 +32,9 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
     ; fi
 
 RUN if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
-    mv bin/armv7-unknown-linux-gnueabihf-lldap-bin/lldap target/lldap && \
-    mv bin/armv7-unknown-linux-gnueabihf-lldap_migration_tool-bin/lldap_migration_tool target/lldap_migration_tool && \
-    mv bin/armv7-unknown-linux-gnueabihf-lldap_set_password-bin/lldap_set_password target/lldap_set_password && \
+    mv bin/armv7-unknown-linux-musleabihf-lldap-bin/lldap target/lldap && \
+    mv bin/armv7-unknown-linux-musleabihf-lldap_migration_tool-bin/lldap_migration_tool target/lldap_migration_tool && \
+    mv bin/armv7-unknown-linux-musleabihf-lldap_set_password-bin/lldap_set_password target/lldap_set_password && \
     chmod +x target/lldap && \
     chmod +x target/lldap_migration_tool && \
     chmod +x target/lldap_set_password && \

--- a/.github/workflows/Dockerfile.ci.debian
+++ b/.github/workflows/Dockerfile.ci.debian
@@ -32,9 +32,9 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
     ; fi
 
 RUN if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
-    mv bin/armv7-unknown-linux-gnueabihf-lldap-bin/lldap target/lldap && \
-    mv bin/armv7-unknown-linux-gnueabihf-lldap_migration_tool-bin/lldap_migration_tool target/lldap_migration_tool && \
-    mv bin/armv7-unknown-linux-gnueabihf-lldap_set_password-bin/lldap_set_password target/lldap_set_password && \
+    mv bin/armv7-unknown-linux-musleabihf-lldap-bin/lldap target/lldap && \
+    mv bin/armv7-unknown-linux-musleabihf-lldap_migration_tool-bin/lldap_migration_tool target/lldap_migration_tool && \
+    mv bin/armv7-unknown-linux-musleabihf-lldap_set_password-bin/lldap_set_password target/lldap_set_password && \
     chmod +x target/lldap && \
     chmod +x target/lldap_migration_tool && \
     chmod +x target/lldap_set_password && \

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -128,7 +128,7 @@ jobs:
     container:
       image: nitnelave/rust-dev:latest
       env:
-        CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+        CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER: arm-linux-gnueabihf-gcc
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-gnu-gcc
         CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -122,6 +122,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.event_name == 'release' }}
     strategy:
+      fail-fast: false
       matrix:
         target: [armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl]
     container:
@@ -132,7 +133,7 @@ jobs:
         CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-gnu-gcc
         CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc
         CC_aarch64_unknown_linux_musl: aarch64-linux-gnu-gcc
-        CC_x86_64_unknown_linux_musl: x86_86-linux-gnu-gcc
+        CC_x86_64_unknown_linux_musl: x86_64-linux-gnu-gcc
         CARGO_TERM_COLOR: always
         RUSTFLAGS: -Ctarget-feature=+crt-static
         CARGO_HOME: ${GITHUB_WORKSPACE}/.cargo

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -126,7 +126,7 @@ jobs:
       matrix:
         target: [armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl]
     container:
-      image: nitnelave/rust-dev:latest
+      image: lldap/rust-dev:latest
       env:
         CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER: arm-linux-gnueabihf-gcc
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -123,13 +123,16 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.event_name == 'release' }}
     strategy:
       matrix:
-        target: [armv7-unknown-linux-gnueabihf, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl]
+        target: [armv7-unknown-linux-musleabihf, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl]
     container:
       image: nitnelave/rust-dev:latest
       env:
         CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-musl-gcc
-        CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-musl-gcc
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+        CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-gnu-gcc
+        CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc
+        CC_aarch64_unknown_linux_musl: aarch64-linux-gnu-gcc
+        CC_x86_64_unknown_linux_musl: x86_86-linux-gnu-gcc
         CARGO_TERM_COLOR: always
         RUSTFLAGS: -Ctarget-feature=+crt-static
         CARGO_HOME: ${GITHUB_WORKSPACE}/.cargo

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -39,9 +39,12 @@ env:
 # GitHub actions randomly timeout when downloading musl-gcc, using custom dev image   #
 # Look into .github/workflows/Dockerfile.dev for development image details            #
 # Using lldap dev image based on https://hub.docker.com/_/rust and musl-gcc bundled   #
+# lldap/rust-dev:latest                                                               #
 #######################################################################################
 ### Cargo build
-### aarch64 and amd64 is musl based
+### armv7, aarch64 and amd64 is musl based
+
+### This not an issue anymore when using rust 1.71 forward
 ### armv7 is glibc based, musl had issue with time_t when cross compile https://github.com/rust-lang/libc/issues/1848
 
 # build-ui,builds-armhf, build-aarch64, build-amd64 will upload artifacts will be used next job
@@ -50,8 +53,7 @@ env:
 ### will run lldap with postgres, mariadb and sqlite backend, do selfcheck command.
 
 # Build docker image
-### Triplet docker image arch with debian base
-### amd64 & aarch64 with alpine base
+### Triplet docker image arch with debian and alpine base
 # build-docker-image job will fetch artifacts and run Dockerfile.ci then push the image.
 ### Look into .github/workflows/Dockerfile.ci.debian or .github/workflowds/Dockerfile.ci.alpine
 
@@ -590,13 +592,13 @@ jobs:
         run: |
              mv bin/aarch64-unknown-linux-musl-lldap-bin/lldap bin/aarch64-lldap
              mv bin/x86_64-unknown-linux-musl-lldap-bin/lldap bin/amd64-lldap
-             mv bin/armv7-unknown-linux-gnueabihf-lldap-bin/lldap bin/armhf-lldap
+             mv bin/armv7-unknown-linux-musleabihf-lldap-bin/lldap bin/armhf-lldap
              mv bin/aarch64-unknown-linux-musl-lldap_migration_tool-bin/lldap_migration_tool bin/aarch64-lldap_migration_tool
              mv bin/x86_64-unknown-linux-musl-lldap_migration_tool-bin/lldap_migration_tool bin/amd64-lldap_migration_tool
-             mv bin/armv7-unknown-linux-gnueabihf-lldap_migration_tool-bin/lldap_migration_tool bin/armhf-lldap_migration_tool
+             mv bin/armv7-unknown-linux-musleabihf-lldap_migration_tool-bin/lldap_migration_tool bin/armhf-lldap_migration_tool
              mv bin/aarch64-unknown-linux-musl-lldap_set_password-bin/lldap_set_password bin/aarch64-lldap_set_password
              mv bin/x86_64-unknown-linux-musl-lldap_set_password-bin/lldap_set_password bin/amd64-lldap_set_password
-             mv bin/armv7-unknown-linux-gnueabihf-lldap_set_password-bin/lldap_set_password bin/armhf-lldap_set_password
+             mv bin/armv7-unknown-linux-musleabihf-lldap_set_password-bin/lldap_set_password bin/armhf-lldap_set_password
              chmod +x bin/*-lldap
              chmod +x bin/*-lldap_migration_tool
              chmod +x bin/*-lldap_set_password

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -128,12 +128,6 @@ jobs:
     container:
       image: lldap/rust-dev:latest
       env:
-        CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER: arm-linux-gnueabihf-gcc
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
-        CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: x86_64-linux-gnu-gcc
-        CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc
-        CC_aarch64_unknown_linux_musl: aarch64-linux-gnu-gcc
-        CC_x86_64_unknown_linux_musl: x86_64-linux-gnu-gcc
         CARGO_TERM_COLOR: always
         RUSTFLAGS: -Ctarget-feature=+crt-static
         CARGO_HOME: ${GITHUB_WORKSPACE}/.cargo

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -150,6 +150,8 @@ jobs:
           key: lldap-bin-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             lldap-bin-${{ matrix.target }}-
+      - name: add musl armv7
+        run: rustup target add armv7-unknown-linux-musleabihf
       - name: Compile ${{ matrix.target }} lldap and tools
         run: cargo build --target=${{ matrix.target }} --release -p lldap -p lldap_migration_tool -p lldap_set_password
       - name: Check path

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -41,11 +41,8 @@ env:
 # Using lldap dev image based on https://hub.docker.com/_/rust and musl-gcc bundled   #
 # lldap/rust-dev:latest                                                               #
 #######################################################################################
-### Cargo build
+# Cargo build
 ### armv7, aarch64 and amd64 is musl based
-
-### This not an issue anymore when using rust 1.71 forward
-### armv7 is glibc based, musl had issue with time_t when cross compile https://github.com/rust-lang/libc/issues/1848
 
 # build-ui,builds-armhf, build-aarch64, build-amd64 will upload artifacts will be used next job
 
@@ -57,7 +54,7 @@ env:
 # build-docker-image job will fetch artifacts and run Dockerfile.ci then push the image.
 ### Look into .github/workflows/Dockerfile.ci.debian or .github/workflowds/Dockerfile.ci.alpine
 
-# create release artifacts
+# Create release artifacts
 ### Fetch artifacts
 ### Clean up web artifact
 ### Setup folder structure

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -147,8 +147,6 @@ jobs:
           key: lldap-bin-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             lldap-bin-${{ matrix.target }}-
-      - name: add musl armv7
-        run: rustup target add armv7-unknown-linux-musleabihf
       - name: Compile ${{ matrix.target }} lldap and tools
         run: cargo build --target=${{ matrix.target }} --release -p lldap -p lldap_migration_tool -p lldap_set_password
       - name: Check path


### PR DESCRIPTION
~~Building with gnu compiler~~
* [x] ~~Can remove musl-gcc from development image?~~
* [x] Build armv7? Success
* [x] ~~Set image to alpine only?~~ Keep all
* [x] Some cleanup

Issue after change
* [x] Some sqlite3 missing? Incompabily linking with gnu gcc. (use musl-gcc)
* [x] ~~musl-cross armv7l need more older musl [stackoverflow thread](https://stackoverflow.com/questions/61934997/undefined-reference-to-stat-time64-when-cross-compiling-rust-project-on-mu),~~ this is rust issue, confirmed with rust nightly 1.71 (musl lib upgraded to 1.2.3)
* [x] Due sqlite3, can't remove musl compiler (sqlite3 blackmagic)
```
  = note: LC_ALL="C" PATH="/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/self-contained:/opt/aarch64-linux-musl-cross/:/opt/aarch64-linux-musl-cross/bin/:/opt/x86_64-linux-musl-cross/:/opt/x86_64-linux-musl-cross/bin/:/home/debian/cargo/bin/:/home/debian/.local/bin:/home/debian/.local/lib:/home/debian/.local/lib:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" VSLANG="1033" "aarch64-linux-gnu-gcc" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crt1.o" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crti.o" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crtbegin.o" "/tmp/rustc4DNVbh/symbols.o" "/home/debian/lldap/target/aarch64-unknown-linux-musl/release/deps/lldap-300f097551b88f0c.lldap.86dd67ed-cgu.15.rcgu.o" "-Wl,--as-needed" "-L" "/home/debian/lldap/target/aarch64-unknown-linux-musl/release/deps" "-L" "/home/debian/lldap/target/release/deps" "-L" "/home/debian/lldap/target/aarch64-unknown-linux-musl/release/build/zstd-sys-51a13d8dea6e6574/out" "-L" "/home/debian/lldap/target/aarch64-unknown-linux-musl/release/build/ring-42cf3d826bbfb071/out" "-L" "/home/debian/lldap/target/aarch64-unknown-linux-musl/release/build/libsqlite3-sys-5bf0fb41028630c4/out" "-L" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib" "-Wl,-Bstatic" "/tmp/rustc4DNVbh/libzstd_sys-9914a45dfbaea2c1.rlib" "/tmp/rustc4DNVbh/liblibsqlite3_sys-4958aa93929c55a2.rlib" "/tmp/rustc4DNVbh/libring-41f3d2a6f4566385.rlib" "-lunwind" "-lc" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/libcompiler_builtins-50d8ea67cf3a12a5.rlib" "-Wl,-Bdynamic" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-nostartfiles" "-L" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib" "-L" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained" "-o" "/home/debian/lldap/target/aarch64-unknown-linux-musl/release/deps/lldap-300f097551b88f0c" "-Wl,--gc-sections" "-static" "-no-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crtend.o" "/home/debian/rustup/toolchains/1.69.0-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crtn.o"
  = note: /usr/lib/gcc-cross/aarch64-linux-gnu/12/../../../../aarch64-linux-gnu/bin/ld: /tmp/rustc4DNVbh/liblibsqlite3_sys-4958aa93929c55a2.rlib(sqlite3.o):(.data.rel.aSyscall+0xb0): undefined reference to `fcntl64'
          collect2: error: ld returned 1 exit status
          
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)

error: could not compile `lldap` due to previous error
```

Waiting for this
* https://blog.rust-lang.org/2023/05/09/Updating-musl-targets.html
* [x] 1.71 on nightly, wait on stable, waiting for dev image updated
```
debian@6ed2ef4f8fdf:~/lldap$ rustup default nightly
info: using existing install for 'nightly-x86_64-unknown-linux-gnu'
info: default toolchain set to 'nightly-x86_64-unknown-linux-gnu'

  nightly-x86_64-unknown-linux-gnu unchanged - rustc 1.71.0-nightly (e77366b57 2023-05-16)

```
```
   Compiling actix-web-httpauth v0.8.0
   Compiling tracing-actix-web v0.7.2
   Compiling sqlx v0.6.2
   Compiling sea-query-binder v0.3.0
   Compiling sea-orm v0.11.0
   Compiling lldap v0.5.0-alpha (/home/debian/lldap/server)
    Finished release [optimized] target(s) in 7m 59s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v2.2.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
debian@6ed2ef4f8fdf:~/lldap$ CC_armv7_unknown_linux_musleabihf=armv7l-linux-musleabihf-gcc CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=armv7l-linux-musleabihf-gcc CARGO_BUILD_TARGET=armv7-unknown-linux-musleabihf cargo build --release -p lldap
```
```
debian@6ed2ef4f8fdf:~/lldap$ file ./target/armv7-unknown-linux-musleabihf/release/lldap
./target/armv7-unknown-linux-musleabihf/release/lldap: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped

```