### PR TITLE
actions: update mariadb healthcheck

### DIFF
--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -186,7 +186,7 @@ jobs:
             MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
           options: >-
             --name mariadb
-            --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+            --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
         postgresql:
            image: postgres:latest
@@ -281,7 +281,7 @@ jobs:
             MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
           options: >-
             --name mariadb
-            --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+            --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
 
         mysql:
@@ -295,7 +295,7 @@ jobs:
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
           options: >-
             --name mysql
-            --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+            --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
 
     steps:

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -295,7 +295,7 @@ jobs:
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
           options: >-
             --name mysql
-            --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+            --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
 
     steps:


### PR DESCRIPTION
* mariadb:latest v11 container image, don't have reference to `mysql` anymore, update command from `mysqladmin` to `mariadb-admin`