### PR TITLE
enhancement: Emails do not have a message_id

### DIFF
--- a/server/src/infra/mail.rs
+++ b/server/src/infra/mail.rs
@@ -17,7 +17,7 @@ async fn send_email(to: Mailbox, subject: &str, body: String, options: &MailOpti
         &to, &from, &options.user, &options.server, options.port
     );
     let email = Message::builder()
-        .message_id(Some(format!("<{}@{}>", crate::util::get_uuid(), smtp_from.split('@').collect::<Vec<&str>>()[1])))
+        .message_id(Some(format!("<{}@{}>", uuid::Uuid::new_v4().to_string(), from.split('@').collect::<Vec<&str>>()[1])))
         .from(from)
         .reply_to(reply_to)
         .to(to)

--- a/server/src/infra/mail.rs
+++ b/server/src/infra/mail.rs
@@ -17,7 +17,7 @@ async fn send_email(to: Mailbox, subject: &str, body: String, options: &MailOpti
         &to, &from, &options.user, &options.server, options.port
     );
     let email = Message::builder()
-        .message_id(Some(format!("<{}@{}>", uuid::Uuid::new_v4().to_string(), from.split('@').collect::<Vec<&str>>()[1])))
+        .message_id(Some(format!("<{}@{}>", uuid::Uuid::new_v4().to_string(), from.to_string().split('@').collect::<Vec<&str>>()[1])))
         .from(from)
         .reply_to(reply_to)
         .to(to)

--- a/server/src/infra/mail.rs
+++ b/server/src/infra/mail.rs
@@ -17,6 +17,7 @@ async fn send_email(to: Mailbox, subject: &str, body: String, options: &MailOpti
         &to, &from, &options.user, &options.server, options.port
     );
     let email = Message::builder()
+        .message_id(Some(format!("<{}@{}>", crate::util::get_uuid(), smtp_from.split('@').collect::<Vec<&str>>()[1])))
         .from(from)
         .reply_to(reply_to)
         .to(to)


### PR DESCRIPTION
Closes #608 

**Issue Description:**

I noticed that password-reset-mails sent from my system have a higher spam score as expected.
This is because the mails are missing the message-id header.

Usually it is up to the originating client to add this header.
But many email-providers add it automatically if it is missing, because those mails would very likely get flagged as spam and lower their trust score.

Anyway it would be a good thing to not rely on the mailserver to "repair" the mails for us.

I can not implement it myself but here is how another project which is also using lettre solved it.
Maybe someone can get a PR going.