### PR TITLE
Add a graphql method to get the schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -39,6 +39,11 @@ input RequestFilter {
 "DateTime"
 scalar DateTimeUtc
 
+type Schema {
+  userSchema: AttributeList!
+  groupSchema: AttributeList!
+}
+
 "The fields that can be updated for a group."
 input UpdateGroupInput {
   id: Int!
@@ -51,6 +56,7 @@ type Query {
   users(filters: RequestFilter): [User!]!
   groups: [Group!]!
   group(groupId: Int!): Group!
+  schema: Schema!
 }
 
 "The details required to create a user."
@@ -74,6 +80,19 @@ type User {
   uuid: String!
   "The groups to which this user belongs."
   groups: [Group!]!
+}
+
+type AttributeList {
+  attributes: [AttributeSchema!]!
+}
+
+type AttributeSchema {
+  name: String!
+  attributeType: String!
+  isList: Boolean!
+  isVisible: Boolean!
+  isEditable: Boolean!
+  isHardcoded: Boolean!
 }
 
 type Success {

--- a/server/src/domain/handler.rs
+++ b/server/src/domain/handler.rs
@@ -210,49 +210,6 @@ pub trait BackendHandler:
 }
 
 #[cfg(test)]
-mockall::mock! {
-    pub TestBackendHandler{}
-    impl Clone for TestBackendHandler {
-        fn clone(&self) -> Self;
-    }
-    #[async_trait]
-    impl GroupListerBackendHandler for TestBackendHandler {
-        async fn list_groups(&self, filters: Option<GroupRequestFilter>) -> Result<Vec<Group>>;
-    }
-    #[async_trait]
-    impl GroupBackendHandler for TestBackendHandler {
-        async fn get_group_details(&self, group_id: GroupId) -> Result<GroupDetails>;
-        async fn update_group(&self, request: UpdateGroupRequest) -> Result<()>;
-        async fn create_group(&self, group_name: &str) -> Result<GroupId>;
-        async fn delete_group(&self, group_id: GroupId) -> Result<()>;
-    }
-    #[async_trait]
-    impl UserListerBackendHandler for TestBackendHandler {
-        async fn list_users(&self, filters: Option<UserRequestFilter>, get_groups: bool) -> Result<Vec<UserAndGroups>>;
-    }
-    #[async_trait]
-    impl UserBackendHandler for TestBackendHandler {
-        async fn get_user_details(&self, user_id: &UserId) -> Result<User>;
-        async fn create_user(&self, request: CreateUserRequest) -> Result<()>;
-        async fn update_user(&self, request: UpdateUserRequest) -> Result<()>;
-        async fn delete_user(&self, user_id: &UserId) -> Result<()>;
-        async fn get_user_groups(&self, user_id: &UserId) -> Result<HashSet<GroupDetails>>;
-        async fn add_user_to_group(&self, user_id: &UserId, group_id: GroupId) -> Result<()>;
-        async fn remove_user_from_group(&self, user_id: &UserId, group_id: GroupId) -> Result<()>;
-    }
-    #[async_trait]
-    impl SchemaBackendHandler for TestBackendHandler {
-        async fn get_schema(&self) -> Result<Schema>;
-    }
-    #[async_trait]
-    impl BackendHandler for TestBackendHandler {}
-    #[async_trait]
-    impl LoginHandler for TestBackendHandler {
-        async fn bind(&self, request: BindRequest) -> Result<()>;
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use base64::Engine;
 

--- a/server/src/infra/ldap_handler.rs
+++ b/server/src/infra/ldap_handler.rs
@@ -671,73 +671,15 @@ impl<Backend: BackendHandler + LoginHandler + OpaqueHandler> LdapHandler<Backend
 mod tests {
     use super::*;
     use crate::{
-        domain::{error::Result, handler::*, opaque_handler::*, types::*},
+        domain::{handler::*, types::*},
+        infra::test_utils::{setup_default_schema, MockTestBackendHandler},
         uuid,
     };
-    use async_trait::async_trait;
     use chrono::TimeZone;
     use ldap3_proto::proto::{LdapDerefAliases, LdapSearchScope, LdapSubstringFilter};
     use mockall::predicate::eq;
     use std::collections::HashSet;
     use tokio;
-
-    mockall::mock! {
-        pub TestBackendHandler{}
-        impl Clone for TestBackendHandler {
-            fn clone(&self) -> Self;
-        }
-        #[async_trait]
-        impl LoginHandler for TestBackendHandler {
-            async fn bind(&self, request: BindRequest) -> Result<()>;
-        }
-        #[async_trait]
-        impl GroupListerBackendHandler for TestBackendHandler {
-            async fn list_groups(&self, filters: Option<GroupRequestFilter>) -> Result<Vec<Group>>;
-        }
-        #[async_trait]
-        impl GroupBackendHandler for TestBackendHandler {
-            async fn get_group_details(&self, group_id: GroupId) -> Result<GroupDetails>;
-            async fn update_group(&self, request: UpdateGroupRequest) -> Result<()>;
-            async fn create_group(&self, group_name: &str) -> Result<GroupId>;
-            async fn delete_group(&self, group_id: GroupId) -> Result<()>;
-        }
-        #[async_trait]
-        impl UserListerBackendHandler for TestBackendHandler {
-            async fn list_users(&self, filters: Option<UserRequestFilter>, get_groups: bool) -> Result<Vec<UserAndGroups>>;
-        }
-        #[async_trait]
-        impl UserBackendHandler for TestBackendHandler {
-            async fn get_user_details(&self, user_id: &UserId) -> Result<User>;
-            async fn create_user(&self, request: CreateUserRequest) -> Result<()>;
-            async fn update_user(&self, request: UpdateUserRequest) -> Result<()>;
-            async fn delete_user(&self, user_id: &UserId) -> Result<()>;
-            async fn get_user_groups(&self, user_id: &UserId) -> Result<HashSet<GroupDetails>>;
-            async fn add_user_to_group(&self, user_id: &UserId, group_id: GroupId) -> Result<()>;
-            async fn remove_user_from_group(&self, user_id: &UserId, group_id: GroupId) -> Result<()>;
-        }
-        #[async_trait]
-        impl SchemaBackendHandler for TestBackendHandler {
-            async fn get_schema(&self) -> Result<Schema>;
-        }
-        #[async_trait]
-        impl BackendHandler for TestBackendHandler {}
-        #[async_trait]
-        impl OpaqueHandler for TestBackendHandler {
-            async fn login_start(
-                &self,
-                request: login::ClientLoginStartRequest
-            ) -> Result<login::ServerLoginStartResponse>;
-            async fn login_finish(&self, request: login::ClientLoginFinishRequest) -> Result<UserId>;
-            async fn registration_start(
-                &self,
-                request: registration::ClientRegistrationStartRequest
-            ) -> Result<registration::ServerRegistrationStartResponse>;
-            async fn registration_finish(
-                &self,
-                request: registration::ClientRegistrationFinishRequest
-            ) -> Result<()>;
-        }
-    }
 
     fn make_user_search_request<S: Into<String>>(
         filter: LdapFilter,
@@ -805,44 +747,6 @@ mod tests {
         mock: MockTestBackendHandler,
     ) -> LdapHandler<MockTestBackendHandler> {
         setup_bound_handler_with_group(mock, "lldap_admin").await
-    }
-
-    fn setup_default_schema(mock: &mut MockTestBackendHandler) {
-        mock.expect_get_schema().returning(|| {
-            Ok(Schema {
-                user_attributes: AttributeList {
-                    attributes: vec![
-                        AttributeSchema {
-                            name: "avatar".to_owned(),
-                            attribute_type: AttributeType::JpegPhoto,
-                            is_list: false,
-                            is_visible: true,
-                            is_editable: true,
-                            is_hardcoded: true,
-                        },
-                        AttributeSchema {
-                            name: "first_name".to_owned(),
-                            attribute_type: AttributeType::String,
-                            is_list: false,
-                            is_visible: true,
-                            is_editable: true,
-                            is_hardcoded: true,
-                        },
-                        AttributeSchema {
-                            name: "last_name".to_owned(),
-                            attribute_type: AttributeType::String,
-                            is_list: false,
-                            is_visible: true,
-                            is_editable: true,
-                            is_hardcoded: true,
-                        },
-                    ],
-                },
-                group_attributes: AttributeList {
-                    attributes: Vec::new(),
-                },
-            })
-        });
     }
 
     #[tokio::test]

--- a/server/src/infra/mod.rs
+++ b/server/src/infra/mod.rs
@@ -10,6 +10,10 @@ pub mod ldap_handler;
 pub mod ldap_server;
 pub mod logging;
 pub mod mail;
+pub mod schema;
 pub mod sql_backend_handler;
 pub mod tcp_backend_handler;
 pub mod tcp_server;
+
+#[cfg(test)]
+pub mod test_utils;

--- a/server/src/infra/schema.rs
+++ b/server/src/infra/schema.rs
@@ -1,0 +1,104 @@
+use crate::domain::{
+    handler::{AttributeSchema, Schema},
+    types::AttributeType,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct PublicSchema(Schema);
+
+impl PublicSchema {
+    pub fn get_schema(&self) -> &Schema {
+        &self.0
+    }
+}
+
+impl From<Schema> for PublicSchema {
+    fn from(mut schema: Schema) -> Self {
+        schema.user_attributes.attributes.extend_from_slice(&[
+            AttributeSchema {
+                name: "user_id".to_owned(),
+                attribute_type: AttributeType::String,
+                is_list: false,
+                is_visible: true,
+                is_editable: false,
+                is_hardcoded: true,
+            },
+            AttributeSchema {
+                name: "creation_date".to_owned(),
+                attribute_type: AttributeType::DateTime,
+                is_list: false,
+                is_visible: true,
+                is_editable: false,
+                is_hardcoded: true,
+            },
+            AttributeSchema {
+                name: "mail".to_owned(),
+                attribute_type: AttributeType::String,
+                is_list: false,
+                is_visible: true,
+                is_editable: true,
+                is_hardcoded: true,
+            },
+            AttributeSchema {
+                name: "uuid".to_owned(),
+                attribute_type: AttributeType::String,
+                is_list: false,
+                is_visible: true,
+                is_editable: false,
+                is_hardcoded: true,
+            },
+            AttributeSchema {
+                name: "display_name".to_owned(),
+                attribute_type: AttributeType::String,
+                is_list: false,
+                is_visible: true,
+                is_editable: true,
+                is_hardcoded: true,
+            },
+        ]);
+        schema
+            .user_attributes
+            .attributes
+            .sort_by(|a, b| a.name.cmp(&b.name));
+        schema.group_attributes.attributes.extend_from_slice(&[
+            AttributeSchema {
+                name: "group_id".to_owned(),
+                attribute_type: AttributeType::Integer,
+                is_list: false,
+                is_visible: true,
+                is_editable: false,
+                is_hardcoded: true,
+            },
+            AttributeSchema {
+                name: "creation_date".to_owned(),
+                attribute_type: AttributeType::DateTime,
+                is_list: false,
+                is_visible: true,
+                is_editable: false,
+                is_hardcoded: true,
+            },
+            AttributeSchema {
+                name: "uuid".to_owned(),
+                attribute_type: AttributeType::String,
+                is_list: false,
+                is_visible: true,
+                is_editable: false,
+                is_hardcoded: true,
+            },
+            AttributeSchema {
+                name: "display_name".to_owned(),
+                attribute_type: AttributeType::String,
+                is_list: false,
+                is_visible: true,
+                is_editable: true,
+                is_hardcoded: true,
+            },
+        ]);
+        schema
+            .group_attributes
+            .attributes
+            .sort_by(|a, b| a.name.cmp(&b.name));
+        PublicSchema(schema)
+    }
+}

--- a/server/src/infra/test_utils.rs
+++ b/server/src/infra/test_utils.rs
@@ -1,0 +1,100 @@
+use crate::domain::{error::Result, handler::*, opaque_handler::*, types::*};
+
+use async_trait::async_trait;
+use std::collections::HashSet;
+
+mockall::mock! {
+    pub TestBackendHandler{}
+    impl Clone for TestBackendHandler {
+        fn clone(&self) -> Self;
+    }
+    #[async_trait]
+    impl LoginHandler for TestBackendHandler {
+        async fn bind(&self, request: BindRequest) -> Result<()>;
+    }
+    #[async_trait]
+    impl GroupListerBackendHandler for TestBackendHandler {
+        async fn list_groups(&self, filters: Option<GroupRequestFilter>) -> Result<Vec<Group>>;
+    }
+    #[async_trait]
+    impl GroupBackendHandler for TestBackendHandler {
+        async fn get_group_details(&self, group_id: GroupId) -> Result<GroupDetails>;
+        async fn update_group(&self, request: UpdateGroupRequest) -> Result<()>;
+        async fn create_group(&self, group_name: &str) -> Result<GroupId>;
+        async fn delete_group(&self, group_id: GroupId) -> Result<()>;
+    }
+    #[async_trait]
+    impl UserListerBackendHandler for TestBackendHandler {
+        async fn list_users(&self, filters: Option<UserRequestFilter>, get_groups: bool) -> Result<Vec<UserAndGroups>>;
+    }
+    #[async_trait]
+    impl UserBackendHandler for TestBackendHandler {
+        async fn get_user_details(&self, user_id: &UserId) -> Result<User>;
+        async fn create_user(&self, request: CreateUserRequest) -> Result<()>;
+        async fn update_user(&self, request: UpdateUserRequest) -> Result<()>;
+        async fn delete_user(&self, user_id: &UserId) -> Result<()>;
+        async fn get_user_groups(&self, user_id: &UserId) -> Result<HashSet<GroupDetails>>;
+        async fn add_user_to_group(&self, user_id: &UserId, group_id: GroupId) -> Result<()>;
+        async fn remove_user_from_group(&self, user_id: &UserId, group_id: GroupId) -> Result<()>;
+    }
+    #[async_trait]
+    impl SchemaBackendHandler for TestBackendHandler {
+        async fn get_schema(&self) -> Result<Schema>;
+    }
+    #[async_trait]
+    impl BackendHandler for TestBackendHandler {}
+    #[async_trait]
+    impl OpaqueHandler for TestBackendHandler {
+        async fn login_start(
+            &self,
+            request: login::ClientLoginStartRequest
+        ) -> Result<login::ServerLoginStartResponse>;
+        async fn login_finish(&self, request: login::ClientLoginFinishRequest) -> Result<UserId>;
+        async fn registration_start(
+            &self,
+            request: registration::ClientRegistrationStartRequest
+        ) -> Result<registration::ServerRegistrationStartResponse>;
+        async fn registration_finish(
+            &self,
+            request: registration::ClientRegistrationFinishRequest
+        ) -> Result<()>;
+    }
+}
+
+pub fn setup_default_schema(mock: &mut MockTestBackendHandler) {
+    mock.expect_get_schema().returning(|| {
+        Ok(Schema {
+            user_attributes: AttributeList {
+                attributes: vec![
+                    AttributeSchema {
+                        name: "avatar".to_owned(),
+                        attribute_type: AttributeType::JpegPhoto,
+                        is_list: false,
+                        is_visible: true,
+                        is_editable: true,
+                        is_hardcoded: true,
+                    },
+                    AttributeSchema {
+                        name: "first_name".to_owned(),
+                        attribute_type: AttributeType::String,
+                        is_list: false,
+                        is_visible: true,
+                        is_editable: true,
+                        is_hardcoded: true,
+                    },
+                    AttributeSchema {
+                        name: "last_name".to_owned(),
+                        attribute_type: AttributeType::String,
+                        is_list: false,
+                        is_visible: true,
+                        is_editable: true,
+                        is_hardcoded: true,
+                    },
+                ],
+            },
+            group_attributes: AttributeList {
+                attributes: Vec::new(),
+            },
+        })
+    });
+}


### PR DESCRIPTION
I chose to decouple the domain-level configurable attributes, and the public-viewable schema which includes the attributes that are not stored as "user attributes". All the "hardcoded" attributes will be available as fields from grahpql, and the non-hardcoded will be only in the "user_attributes" (coming) field.

In terms of permissions, only users who have the permissions to see all the users (admin, password manager or readonly) can see the schema. Regular users cannot (they wouldn't have much use for it, and that way I don't have to filter the fields they're not allowed to see).