### PR TITLE
ldap: Add support for modifying the password with a modify operation

### DIFF
--- a/app/src/components/change_password.rs
+++ b/app/src/components/change_password.rs
@@ -128,9 +128,11 @@ impl CommonComponent<ChangePasswordForm> for ChangePasswordForm {
             Msg::SubmitNewPassword => {
                 let mut rng = rand::rngs::OsRng;
                 let new_password = self.form.model().password;
-                let registration_start_request =
-                    opaque::client::registration::start_registration(&new_password, &mut rng)
-                        .context("Could not initiate password change")?;
+                let registration_start_request = opaque::client::registration::start_registration(
+                    new_password.as_bytes(),
+                    &mut rng,
+                )
+                .context("Could not initiate password change")?;
                 let req = registration::ClientRegistrationStartRequest {
                     username: ctx.props().username.clone(),
                     registration_start_request: registration_start_request.message,

--- a/app/src/components/create_user.rs
+++ b/app/src/components/create_user.rs
@@ -117,7 +117,10 @@ impl CommonComponent<CreateUserForm> for CreateUserForm {
                     let opaque::client::registration::ClientRegistrationStartResult {
                         state,
                         message,
-                    } = opaque::client::registration::start_registration(&password, &mut rng)?;
+                    } = opaque::client::registration::start_registration(
+                        password.as_bytes(),
+                        &mut rng,
+                    )?;
                     let req = registration::ClientRegistrationStartRequest {
                         username: user_id,
                         registration_start_request: message,

--- a/app/src/components/reset_password_step2.rs
+++ b/app/src/components/reset_password_step2.rs
@@ -65,7 +65,7 @@ impl CommonComponent<ResetPasswordStep2Form> for ResetPasswordStep2Form {
                 let mut rng = rand::rngs::OsRng;
                 let new_password = self.form.model().password;
                 let registration_start_request =
-                    opaque_registration::start_registration(&new_password, &mut rng)
+                    opaque_registration::start_registration(new_password.as_bytes(), &mut rng)
                         .context("Could not initiate password change")?;
                 let req = registration::ClientRegistrationStartRequest {
                     username: self.username.clone().unwrap(),

--- a/auth/src/opaque.rs
+++ b/auth/src/opaque.rs
@@ -77,10 +77,10 @@ pub mod client {
         pub use opaque_ke::ClientRegistrationFinishParameters;
         /// Initiate the registration negotiation.
         pub fn start_registration<R: RngCore + CryptoRng>(
-            password: &str,
+            password: &[u8],
             rng: &mut R,
         ) -> AuthenticationResult<ClientRegistrationStartResult> {
-            Ok(ClientRegistration::start(rng, password.as_bytes())?)
+            Ok(ClientRegistration::start(rng, password)?)
         }
 
         /// Finalize the registration negotiation.

--- a/server/src/domain/sql_backend_handler.rs
+++ b/server/src/domain/sql_backend_handler.rs
@@ -59,7 +59,7 @@ pub mod tests {
         insert_user_no_password(handler, name).await;
         let mut rng = rand::rngs::OsRng;
         let client_registration_start =
-            opaque::client::registration::start_registration(pass, &mut rng).unwrap();
+            opaque::client::registration::start_registration(pass.as_bytes(), &mut rng).unwrap();
         let response = handler
             .registration_start(registration::ClientRegistrationStartRequest {
                 username: name.to_string(),

--- a/server/src/domain/sql_opaque_handler.rs
+++ b/server/src/domain/sql_opaque_handler.rs
@@ -210,7 +210,7 @@ pub(crate) async fn register_password(
     let mut rng = rand::rngs::OsRng;
     use registration::*;
     let registration_start =
-        opaque::client::registration::start_registration(password.unsecure(), &mut rng)?;
+        opaque::client::registration::start_registration(password.unsecure().as_bytes(), &mut rng)?;
     let start_response = opaque_handler
         .registration_start(ClientRegistrationStartRequest {
             username: username.to_string(),

--- a/set-password/src/main.rs
+++ b/set-password/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
 
     let mut rng = rand::rngs::OsRng;
     let registration_start_request =
-        opaque::client::registration::start_registration(&opts.password, &mut rng)
+        opaque::client::registration::start_registration(opts.password.as_bytes(), &mut rng)
             .context("Could not initiate password change")?;
     let start_request = registration::ClientRegistrationStartRequest {
         username: opts.username.to_string(),


### PR DESCRIPTION
Fixes #620 

Note that in verbose logging mode, the password will be written in clear in the logs. That was the original motivation for only supporting the extended operation.