### PR TITLE
server: fix smtp encryption parsing

### DIFF
--- a/server/src/infra/cli.rs
+++ b/server/src/infra/cli.rs
@@ -131,6 +131,7 @@ pub struct LdapsOpts {
 
 #[derive(Clone, Debug, Deserialize, Serialize, clap::ValueEnum)]
 #[serde(rename_all = "UPPERCASE")]
+#[clap(rename_all = "UPPERCASE")]
 pub enum SmtpEncryption {
     None,
     Tls,


### PR DESCRIPTION
Otherwise the two parsings of STARTTLS vs start-tls conflict.