### PR TITLE
tests: Use an env variable for the private seed

### DIFF
--- a/server/tests/common/env.rs
+++ b/server/tests/common/env.rs
@@ -2,6 +2,7 @@
 use std::env::var;
 
 pub const DB_KEY: &str = "LLDAP_DATABASE_URL";
+pub const PRIVATE_KEY_SEED: &str = "LLDAP_KEY_SEED";
 
 pub fn database_url() -> String {
     let url = var(DB_KEY).ok();

--- a/server/tests/common/fixture.rs
+++ b/server/tests/common/fixture.rs
@@ -236,5 +236,6 @@ fn create_lldap_command() -> Command {
     let db_url = env::database_url();
     cmd.current_dir(path);
     cmd.env(env::DB_KEY, db_url);
+    cmd.env(env::PRIVATE_KEY_SEED, "Random value");
     cmd
 }


### PR DESCRIPTION
That should help reduce the flakiness of the tests.