### PR TITLE
Remove password length limitation in lldap_set_password tool

### DIFF
--- a/set-password/src/main.rs
+++ b/set-password/src/main.rs
@@ -97,10 +97,6 @@ pub fn register_finish(
 fn main() -> Result<()> {
     let opts = CliOpts::parse();
     ensure!(
-        opts.password.len() >= 8,
-        "New password is too short, expected at least 8 characters"
-    );
-    ensure!(
         opts.base_url.scheme() == "http" || opts.base_url.scheme() == "https",
         "Base URL should start with `http://` or `https://`"
     );

--- a/set-password/src/main.rs
+++ b/set-password/src/main.rs
@@ -30,6 +30,10 @@ pub struct CliOpts {
     /// New password for the user.
     #[clap(short, long)]
     pub password: String,
+
+    /// Should minimum password length be bypassed?
+    #[clap(long)]
+    pub bypass_password_policy: bool,
 }
 
 fn append_to_url(base_url: &Url, path: &str) -> Url {
@@ -96,6 +100,12 @@ pub fn register_finish(
 
 fn main() -> Result<()> {
     let opts = CliOpts::parse();
+    if opts.bypass_password_policy != true {
+        ensure!(
+            opts.password.len() >= 8,
+            "New password is too short, expected at least 8 characters"
+        );
+    }
     ensure!(
         opts.base_url.scheme() == "http" || opts.base_url.scheme() == "https",
         "Base URL should start with `http://` or `https://`"

--- a/set-password/src/main.rs
+++ b/set-password/src/main.rs
@@ -31,7 +31,7 @@ pub struct CliOpts {
     #[clap(short, long)]
     pub password: String,
 
-    /// Should minimum password length be bypassed?
+    /// Bypass password requirements such as minimum length. Unsafe.
     #[clap(long)]
     pub bypass_password_policy: bool,
 }
@@ -100,12 +100,10 @@ pub fn register_finish(
 
 fn main() -> Result<()> {
     let opts = CliOpts::parse();
-    if opts.bypass_password_policy != true {
-        ensure!(
-            opts.password.len() >= 8,
-            "New password is too short, expected at least 8 characters"
-        );
-    }
+    ensure!(
+        opts.bypass_password_policy || opts.password.len() >= 8,
+        "New password is too short, expected at least 8 characters"
+    );
     ensure!(
         opts.base_url.scheme() == "http" || opts.base_url.scheme() == "https",
         "Base URL should start with `http://` or `https://`"


### PR DESCRIPTION
The password length limitation is arbitrary and non-configurable, and there are legitimate requirements to set a password shorter than 8 characters. This change will make it simple to achieve without the need for a third party tool.

I would update the web UI code also, but am unfamiliar with Rust and the wider LLDAP project to confidently make the change and not break something. The change for this tool appears simple, however.