### PR TITLE
chore: update repository references

### DIFF
--- a/app/src/components/app.rs
+++ b/app/src/components/app.rs
@@ -355,7 +355,7 @@ impl App {
               <span>{format!("LLDAP version {}", env!("CARGO_PKG_VERSION"))}</span>
             </div>
             <div>
-              <a href="https://github.com/nitnelave/lldap" class="me-4 text-reset">
+              <a href="https://github.com/lldap/lldap" class="me-4 text-reset">
                 <i class="bi-github"></i>
               </a>
               <a href="https://discord.gg/h5PEdRMNyP" class="me-4 text-reset">
@@ -366,7 +366,7 @@ impl App {
               </a>
             </div>
             <div>
-              <span>{"License "}<a href="https://github.com/nitnelave/lldap/blob/main/LICENSE" class="link-secondary">{"GNU GPL"}</a></span>
+              <span>{"License "}<a href="https://github.com/lldap/lldap/blob/main/LICENSE" class="link-secondary">{"GNU GPL"}</a></span>
             </div>
           </footer>
         }

--- a/docs/database_migration.md
+++ b/docs/database_migration.md
@@ -108,4 +108,4 @@ Modify your `database_url` in `lldap_config.toml` (or `LLDAP_DATABASE_URL` in th
 to point to your new database (the same value used when generating schema). Restart
 LLDAP and check the logs to ensure there were no errors.
 
-#### More details/examples can be seen in the CI process [here](https://raw.githubusercontent.com/nitnelave/lldap/main/.github/workflows/docker-build-static.yml), look for the job `lldap-database-migration-test`
+#### More details/examples can be seen in the CI process [here](https://raw.githubusercontent.com/lldap/lldap/main/.github/workflows/docker-build-static.yml), look for the job `lldap-database-migration-test`

--- a/example_configs/lldap.service
+++ b/example_configs/lldap.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Nitnelave LLDAP
-Documentation=https://github.com/nitnelave/lldap
+Documentation=https://github.com/lldap/lldap
 
 # Only sqlite
 After=network.target

--- a/example_configs/nextcloud_oidc_authelia.md
+++ b/example_configs/nextcloud_oidc_authelia.md
@@ -2,7 +2,7 @@
 
 If you're here, there are some assumptions being made about access and capabilities you have on your system:
 1. You have Authelia up and running, understand its functionality, and have read through the documentation. 
-2. You have [LLDAP](https://github.com/nitnelave/lldap) up and running. 
+2. You have [LLDAP](https://github.com/lldap/lldap) up and running. 
 3. You have Nextcloud and LLDAP communicating and without any config errors. See the [example config for Nextcloud](nextcloud.md)
 
 ## Authelia
@@ -87,4 +87,4 @@ If this is set to *true* then the user flow will _skip_ the login page and autom
 ### Conclusion
 And that's it! Assuming all the settings that worked for me, work for you, you should be able to login using OpenID Connect via Authelia. If you find any errors, it's a good idea to keep a document of all your settings from Authelia/Nextcloud/LLDAP etc so that you can easily reference and ensure everything lines up.
 
-If you have any issues, please create a [discussion](https://github.com/nitnelave/lldap/discussions) or join the [Discord](https://discord.gg/h5PEdRMNyP).
+If you have any issues, please create a [discussion](https://github.com/lldap/lldap/discussions) or join the [Discord](https://discord.gg/h5PEdRMNyP).


### PR DESCRIPTION
There were still some references to the old repository at `nitnelave/lldap` _(most notably in the footer of the web interface)_.