### PR TITLE
Documentation: add installation instructions to install from package repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - [Installation](#installation)
   - [With Docker](#with-docker)
   - [With Kubernetes](#with-kubernetes)
+  - [From a package repository](#from-a-package-repository)
   - [From source](#from-source)
     - [Backend](#backend)
     - [Frontend](#frontend)
@@ -180,7 +181,7 @@ Arch Linux offers unofficial support through the [Arch User Repository
 (AUR)](https://wiki.archlinux.org/title/Arch_User_Repository).
 Available package descriptions in AUR are:
 
-- [lldap](https://aur.archlinux.org/packages/lldap-bin) -  Builds the latest stable version.
+- [lldap](https://aur.archlinux.org/packages/lldap) -  Builds the latest stable version.
 - [lldap-bin](https://aur.archlinux.org/packages/lldap-bin) - Uses the latest
   pre-compiled binaries from the [releases in this repository](https://github.com/lldap/lldap/releases).
   This package is recommended if you want to run lldap on a system with

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ using [bootstrap.sh](example_configs/bootstrap/bootstrap.md#kubernetes-job).
 It can be run by Argo CD for managing users in git-opt way, or as a one-shot job.
 
 ### From a package repository
-** Do not open issues in this repository for problems with third-party
+**Do not open issues in this repository for problems with third-party
 pre-built packages. Report issues downstream.**
 
 Depending on the distribution you use, it might be possible to install lldap
@@ -180,14 +180,16 @@ Arch Linux offers unofficial support through the [Arch User Repository
 (AUR)](https://wiki.archlinux.org/title/Arch_User_Repository).
 Available package descriptions in AUR are:
 
-- `[lldap](https://aur.archlinux.org/packages/lldap-bin)` -  Builds the latest stable version.
-- `[lldap-bin](https://aur.archlinux.org/packages/lldap-bin)` - Uses the latest
+- [lldap](https://aur.archlinux.org/packages/lldap-bin) -  Builds the latest stable version.
+- [lldap-bin](https://aur.archlinux.org/packages/lldap-bin) - Uses the latest
   pre-compiled binaries from the [releases in this repository](https://github.com/lldap/lldap/releases).
   This package is recommended if you want to run lldap on a system with
-  limited CPU and RAM capacity.
-- `[lldap-git](https://aur.archlinux.org/packages/lldap-git)` - Builds the latest main branch code.
+  limited resources.
+- [lldap-git](https://aur.archlinux.org/packages/lldap-git) - Builds the
+  latest main branch code.
 
-The package descriptions can be used [to create and install packages].
+The package descriptions can be used
+[to create and install packages](https://wiki.archlinux.org/title/Arch_User_Repository#Getting_started).
 Each package places lldap's configuration file at `/etc/lldap.toml` and offers
 [systemd service](https://wiki.archlinux.org/title/systemd#Using_units)
 `lldap.service` to (auto-)start and stop lldap.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,32 @@ You can bootstrap your lldap instance (users, groups)
 using [bootstrap.sh](example_configs/bootstrap/bootstrap.md#kubernetes-job).
 It can be run by Argo CD for managing users in git-opt way, or as a one-shot job.
 
+### From a package repository
+** Do not open issues in this repository for problems with third-party
+pre-built packages. Report issues downstream.**
+
+Depending on the distribution you use, it might be possible to install lldap
+from a package repository, officially supported by the distribution or
+community contributed.
+
+#### Arch Linux
+
+Arch Linux offers unofficial support through the [Arch User Repository
+(AUR)](https://wiki.archlinux.org/title/Arch_User_Repository).
+Available package descriptions in AUR are:
+
+- `[lldap](https://aur.archlinux.org/packages/lldap-bin)` -  Builds the latest stable version.
+- `[lldap-bin](https://aur.archlinux.org/packages/lldap-bin)` - Uses the latest
+  pre-compiled binaries from the [releases in this repository](https://github.com/lldap/lldap/releases).
+  This package is recommended if you want to run lldap on a system with
+  limited CPU and RAM capacity.
+- `[lldap-git](https://aur.archlinux.org/packages/lldap-git)` - Builds the latest main branch code.
+
+The package descriptions can be used [to create and install packages].
+Each package places lldap's configuration file at `/etc/lldap.toml` and offers
+[systemd service](https://wiki.archlinux.org/title/systemd#Using_units)
+`lldap.service` to (auto-)start and stop lldap.
+
 ### From source
 
 #### Backend


### PR DESCRIPTION
Currently README.md mentions Docker, Kubernetes, and (manually) from source as installation options. Since lldap is showing up in the Arch User Repository for Arch Linux, I thought it would be handy to have a section in the documentation dedicated to installation of lldap from package repositories. I put a warning on top of this part of the documentation that issues with downstream packages should be reported downstream and not here.

Full disclosure :smile::
I am the author of the [`lldap-bin`](https://aur.archlinux.org/packages/lldap-bin) AUR package description. It would be helpful to point users to this and the other lldap package descriptions if they are using Arch Linux. And hopefully lldap will also be available directly in other distributions.

