### PR TITLE
Use correct Manager DN in Jenkins configuration

### DIFF
--- a/example_configs/jenkins.md
+++ b/example_configs/jenkins.md
@@ -56,7 +56,7 @@ Select Search for LDAP groups containing user and leave Group membership filter 
 #### Manager DN
 Leave here your admin account
 ```
-cn=admin,ou=people
+cn=admin,ou=people,dc=example,dc=com
 ```
 #### Manager Password
 Leave it as is


### PR DESCRIPTION
Referring to the official documentation, the Manager DN should contain 'dc'

> If your LDAP server doesn't support [anonymous binding](http://www.google.com/?q=LDAP+anonymous+bind) (IOW, if your LDAP server doesn't even allow a query without authentication), then Jenkins would have to first authenticate itself against the LDAP server, and Jenkins does that by sending "manager" DN and password.
A DN typically looks like CN=MyUser,CN=Users,DC=mydomain,DC=com although the exact sequence of tokens depends on the LDAP server configuration. It can be any valid DN as long as LDAP allows this user to query data.

> This configuration is also useful when you are connecting to Active Directory from a Unix machine, as AD doesn't allow anonymous bind by default. But if you can't figure this out, you can also change AD setting to allow anonymous bind. See [this document](http://www.novell.com/coolsolutions/appnote/15120.html) for how to.