### PR TITLE
Update config with clearer instructions for setting listen address in a docker setup

### DIFF
--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -10,7 +10,9 @@
 ## The host address that the LDAP server will be bound to.
 ## To enable IPv6 support, simply switch "ldap_host" to "::":
 ## To only allow connections from localhost (if you want to restrict to local self-hosted services),
-## change it to "127.0.0.1" ("::1" in case of IPv6)".
+## change it to "127.0.0.1" ("::1" in case of IPv6).
+## If LLDAP server is running in docker, set it to "0.0.0.0" ("::" for IPv6) to allow connections
+## originating from outside the container.
 #ldap_host = "0.0.0.0"
 
 ## The port on which to have the LDAP server.
@@ -19,7 +21,9 @@
 ## The host address that the HTTP server will be bound to.
 ## To enable IPv6 support, simply switch "http_host" to "::".
 ## To only allow connections from localhost (if you want to restrict to local self-hosted services),
-## change it to "127.0.0.1" ("::1" in case of IPv6)".
+## change it to "127.0.0.1" ("::1" in case of IPv6).
+## If LLDAP server is running in docker, set it to "0.0.0.0" ("::" for IPv6) to allow connections
+## originating from outside the container.
 #http_host = "0.0.0.0"
 
 ## The port on which to have the HTTP server, for user login and


### PR DESCRIPTION
Updated the config template to make it clear that the user should not set LLDAP server to listen on localhost if it is running in a docker container as it would then not be able to accept connections originating from outside the container.