### PR TITLE
app: make it possible to serve lldap behind a sub-path

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,8 @@
 <head>
     <meta charset="utf-8" />
     <title>LLDAP Administration</title>
-    <script src="/static/main.js" type="module" defer></script>
+    <base href="/">
+    <script src="static/main.js" type="module" defer></script>
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap-dark-5@1.1.3/dist/css/bootstrap-nightshade.min.css"
       rel="preload stylesheet"
@@ -33,7 +34,7 @@
       href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" />
     <link
       rel="stylesheet"
-      href="/static/style.css" />
+      href="static/style.css" />
     <script>
       function inDarkMode(){
         return darkmode.inDarkMode;

--- a/app/src/components/app.rs
+++ b/app/src/components/app.rs
@@ -268,7 +268,7 @@ impl App {
           <header class="p-2 mb-3 border-bottom">
             <div class="container">
               <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
-                <a href="/" class="d-flex align-items-center mt-2 mb-lg-0 me-md-5 text-decoration-none">
+                <a href={yew_router::utils::base_url().unwrap_or("/".to_string())} class="d-flex align-items-center mt-2 mb-lg-0 me-md-5 text-decoration-none">
                   <h2>{"LLDAP"}</h2>
                 </a>
 

--- a/app/src/infra/cookies.rs
+++ b/app/src/infra/cookies.rs
@@ -22,10 +22,11 @@ pub fn set_cookie(cookie_name: &str, value: &str, expiration: &DateTime<Utc>) ->
                 .map_err(|_| anyhow!("Document is not an HTMLDocument"))
         })?;
     let cookie_string = format!(
-        "{}={}; expires={}; sameSite=Strict; path=/",
+        "{}={}; expires={}; sameSite=Strict; path={}/",
         cookie_name,
         value,
-        expiration.to_rfc2822()
+        expiration.to_rfc2822(),
+        yew_router::utils::base_url().unwrap_or_default()
     );
     doc.set_cookie(&cookie_string)
         .map_err(|_| anyhow!("Could not set cookie"))


### PR DESCRIPTION
This adds support for placing lldap on a sub-path.

To use it, a User needs to set the `http_url` setting to a URL with a sub-path (`http://example.com/lldap`) and setup the reverse-proxy to strip the sub-path.
Caddy example:
```
handle_path /lldap* {
  reverse_proxy http://127.0.0.1:17170
}
```

Future Work:
Currently, the sub-path is injected every time `index.html` and `main.js` are called, but this could be cached instead.
I tried it, but I never used actix before, and thus couldn't make it work.