### PR TITLE
Fix the Bootstrap script skipping similar name dgroups

### DIFF
--- a/example_configs/bootstrap/bootstrap.sh
+++ b/example_configs/bootstrap/bootstrap.sh
@@ -111,7 +111,7 @@ get_group_array() {
 }
 
 group_exists() {
-  if [[ "$(get_group_list | jq --raw-output --arg displayName "$1" '.data.groups | any(.[]; contains({"displayName": $displayName}))')" == 'true' ]]; then
+  if [[ "$(get_group_list | jq --raw-output --arg displayName "$1" '.data.groups | any(.[]; select(.displayName == $displayName))')" == 'true' ]]; then
     return 0
   else
     return 1
@@ -187,7 +187,7 @@ user_in_group() {
     return
   fi
 
-  if [[ "$(get_user_details "$user_id" | jq --raw-output --arg displayName "$group_name" '.data.user.groups | any(.[]; contains({"displayName": $displayName}))')" == 'true' ]]; then
+  if [[ "$(get_user_details "$user_id" | jq --raw-output --arg displayName "$group_name" '.data.user.groups | any(.[]; select(.displayName == $displayName))')" == 'true' ]]; then
     return 0
   else
     return 1


### PR DESCRIPTION
Existing existing group checking logic used jq's "contain" which confusingly will do partial string matches. For example a group named "media_admin" will be created then "media" will be skipped saying it already exists when it does not. This also occurs for adding groups to users. I noticed this issue when bootstrapping LLDAP on my K3S cluster. Restested the script after my changes and confirm it now works as expected.