### PR TITLE
server: make attributes names, group names and emails case insensitive

### DIFF
--- a/server/src/domain/model/group_attribute_schema.rs
+++ b/server/src/domain/model/group_attribute_schema.rs
@@ -1,7 +1,10 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::{handler::AttributeSchema, types::AttributeType};
+use crate::domain::{
+    handler::AttributeSchema,
+    types::{AttributeName, AttributeType},
+};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "group_attribute_schema")]
@@ -11,7 +14,7 @@ pub struct Model {
         auto_increment = false,
         column_name = "group_attribute_schema_name"
     )]
-    pub attribute_name: String,
+    pub attribute_name: AttributeName,
     #[sea_orm(column_name = "group_attribute_schema_type")]
     pub attribute_type: AttributeType,
     #[sea_orm(column_name = "group_attribute_schema_is_list")]

--- a/server/src/domain/model/group_attributes.rs
+++ b/server/src/domain/model/group_attributes.rs
@@ -1,7 +1,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::types::{AttributeValue, GroupId, Serialized};
+use crate::domain::types::{AttributeName, AttributeValue, GroupId, Serialized};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "group_attributes")]
@@ -17,7 +17,7 @@ pub struct Model {
         auto_increment = false,
         column_name = "group_attribute_name"
     )]
-    pub attribute_name: String,
+    pub attribute_name: AttributeName,
     #[sea_orm(column_name = "group_attribute_value")]
     pub value: Serialized,
 }

--- a/server/src/domain/model/groups.rs
+++ b/server/src/domain/model/groups.rs
@@ -3,14 +3,15 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::types::{GroupId, Uuid};
+use crate::domain::types::{GroupId, GroupName, Uuid};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "groups")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub group_id: GroupId,
-    pub display_name: String,
+    pub display_name: GroupName,
+    pub lowercase_display_name: String,
     pub creation_date: chrono::NaiveDateTime,
     pub uuid: Uuid,
 }

--- a/server/src/domain/model/user_attribute_schema.rs
+++ b/server/src/domain/model/user_attribute_schema.rs
@@ -1,7 +1,10 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::{handler::AttributeSchema, types::AttributeType};
+use crate::domain::{
+    handler::AttributeSchema,
+    types::{AttributeName, AttributeType},
+};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "user_attribute_schema")]
@@ -11,7 +14,7 @@ pub struct Model {
         auto_increment = false,
         column_name = "user_attribute_schema_name"
     )]
-    pub attribute_name: String,
+    pub attribute_name: AttributeName,
     #[sea_orm(column_name = "user_attribute_schema_type")]
     pub attribute_type: AttributeType,
     #[sea_orm(column_name = "user_attribute_schema_is_list")]

--- a/server/src/domain/model/user_attributes.rs
+++ b/server/src/domain/model/user_attributes.rs
@@ -1,7 +1,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::types::{AttributeValue, Serialized, UserId};
+use crate::domain::types::{AttributeName, AttributeValue, Serialized, UserId};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
 #[sea_orm(table_name = "user_attributes")]
@@ -17,7 +17,7 @@ pub struct Model {
         auto_increment = false,
         column_name = "user_attribute_name"
     )]
-    pub attribute_name: String,
+    pub attribute_name: AttributeName,
     #[sea_orm(column_name = "user_attribute_value")]
     pub value: Serialized,
 }

--- a/server/src/domain/model/users.rs
+++ b/server/src/domain/model/users.rs
@@ -3,7 +3,7 @@
 use sea_orm::{entity::prelude::*, sea_query::BlobSize};
 use serde::{Deserialize, Serialize};
 
-use crate::domain::types::{UserId, Uuid};
+use crate::domain::types::{Email, UserId, Uuid};
 
 #[derive(Copy, Clone, Default, Debug, DeriveEntity)]
 pub struct Entity;
@@ -13,7 +13,8 @@ pub struct Entity;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub user_id: UserId,
-    pub email: String,
+    pub email: Email,
+    pub lowercase_email: String,
     pub display_name: Option<String>,
     pub creation_date: chrono::NaiveDateTime,
     pub password_hash: Option<Vec<u8>>,
@@ -32,6 +33,7 @@ impl EntityName for Entity {
 pub enum Column {
     UserId,
     Email,
+    LowercaseEmail,
     DisplayName,
     CreationDate,
     PasswordHash,
@@ -47,6 +49,7 @@ impl ColumnTrait for Column {
         match self {
             Column::UserId => ColumnType::String(Some(255)),
             Column::Email => ColumnType::String(Some(255)),
+            Column::LowercaseEmail => ColumnType::String(Some(255)),
             Column::DisplayName => ColumnType::String(Some(255)),
             Column::CreationDate => ColumnType::DateTime,
             Column::PasswordHash => ColumnType::Binary(BlobSize::Medium),

--- a/server/src/domain/schema.rs
+++ b/server/src/domain/schema.rs
@@ -37,7 +37,7 @@ impl From<Schema> for PublicSchema {
     fn from(mut schema: Schema) -> Self {
         schema.user_attributes.attributes.extend_from_slice(&[
             AttributeSchema {
-                name: "user_id".to_owned(),
+                name: "user_id".into(),
                 attribute_type: AttributeType::String,
                 is_list: false,
                 is_visible: true,
@@ -45,7 +45,7 @@ impl From<Schema> for PublicSchema {
                 is_hardcoded: true,
             },
             AttributeSchema {
-                name: "creation_date".to_owned(),
+                name: "creation_date".into(),
                 attribute_type: AttributeType::DateTime,
                 is_list: false,
                 is_visible: true,
@@ -53,7 +53,7 @@ impl From<Schema> for PublicSchema {
                 is_hardcoded: true,
             },
             AttributeSchema {
-                name: "mail".to_owned(),
+                name: "mail".into(),
                 attribute_type: AttributeType::String,
                 is_list: false,
                 is_visible: true,
@@ -61,7 +61,7 @@ impl From<Schema> for PublicSchema {
                 is_hardcoded: true,
             },
             AttributeSchema {
-                name: "uuid".to_owned(),
+                name: "uuid".into(),
                 attribute_type: AttributeType::String,
                 is_list: false,
                 is_visible: true,
@@ -69,7 +69,7 @@ impl From<Schema> for PublicSchema {
                 is_hardcoded: true,
             },
             AttributeSchema {
-                name: "display_name".to_owned(),
+                name: "display_name".into(),
                 attribute_type: AttributeType::String,
                 is_list: false,
                 is_visible: true,
@@ -83,7 +83,7 @@ impl From<Schema> for PublicSchema {
             .sort_by(|a, b| a.name.cmp(&b.name));
         schema.group_attributes.attributes.extend_from_slice(&[
             AttributeSchema {
-                name: "group_id".to_owned(),
+                name: "group_id".into(),
                 attribute_type: AttributeType::Integer,
                 is_list: false,
                 is_visible: true,
@@ -91,7 +91,7 @@ impl From<Schema> for PublicSchema {
                 is_hardcoded: true,
             },
             AttributeSchema {
-                name: "creation_date".to_owned(),
+                name: "creation_date".into(),
                 attribute_type: AttributeType::DateTime,
                 is_list: false,
                 is_visible: true,
@@ -99,7 +99,7 @@ impl From<Schema> for PublicSchema {
                 is_hardcoded: true,
             },
             AttributeSchema {
-                name: "uuid".to_owned(),
+                name: "uuid".into(),
                 attribute_type: AttributeType::String,
                 is_list: false,
                 is_visible: true,
@@ -107,7 +107,7 @@ impl From<Schema> for PublicSchema {
                 is_hardcoded: true,
             },
             AttributeSchema {
-                name: "display_name".to_owned(),
+                name: "display_name".into(),
                 attribute_type: AttributeType::String,
                 is_list: false,
                 is_visible: true,

--- a/server/src/domain/sql_backend_handler.rs
+++ b/server/src/domain/sql_backend_handler.rs
@@ -87,7 +87,7 @@ pub mod tests {
         handler
             .create_user(CreateUserRequest {
                 user_id: UserId::new(name),
-                email: format!("{}@bob.bob", name),
+                email: format!("{}@bob.bob", name).into(),
                 display_name: Some("display ".to_string() + name),
                 first_name: Some("first ".to_string() + name),
                 last_name: Some("last ".to_string() + name),
@@ -100,7 +100,7 @@ pub mod tests {
     pub async fn insert_group(handler: &SqlBackendHandler, name: &str) -> GroupId {
         handler
             .create_group(CreateGroupRequest {
-                display_name: name.to_owned(),
+                display_name: name.into(),
                 ..Default::default()
             })
             .await

--- a/server/src/domain/sql_schema_backend_handler.rs
+++ b/server/src/domain/sql_schema_backend_handler.rs
@@ -6,6 +6,7 @@ use crate::domain::{
     },
     model,
     sql_backend_handler::SqlBackendHandler,
+    types::AttributeName,
 };
 use async_trait::async_trait;
 use sea_orm::{
@@ -52,15 +53,15 @@ impl SchemaBackendHandler for SqlBackendHandler {
         Ok(())
     }
 
-    async fn delete_user_attribute(&self, name: &str) -> Result<()> {
-        model::UserAttributeSchema::delete_by_id(name)
+    async fn delete_user_attribute(&self, name: &AttributeName) -> Result<()> {
+        model::UserAttributeSchema::delete_by_id(name.clone())
             .exec(&self.sql_pool)
             .await?;
         Ok(())
     }
 
-    async fn delete_group_attribute(&self, name: &str) -> Result<()> {
-        model::GroupAttributeSchema::delete_by_id(name)
+    async fn delete_group_attribute(&self, name: &AttributeName) -> Result<()> {
+        model::GroupAttributeSchema::delete_by_id(name.clone())
             .exec(&self.sql_pool)
             .await?;
         Ok(())
@@ -123,7 +124,7 @@ mod tests {
                 user_attributes: AttributeList {
                     attributes: vec![
                         AttributeSchema {
-                            name: "avatar".to_owned(),
+                            name: "avatar".into(),
                             attribute_type: AttributeType::JpegPhoto,
                             is_list: false,
                             is_visible: true,
@@ -131,7 +132,7 @@ mod tests {
                             is_hardcoded: true,
                         },
                         AttributeSchema {
-                            name: "first_name".to_owned(),
+                            name: "first_name".into(),
                             attribute_type: AttributeType::String,
                             is_list: false,
                             is_visible: true,
@@ -139,7 +140,7 @@ mod tests {
                             is_hardcoded: true,
                         },
                         AttributeSchema {
-                            name: "last_name".to_owned(),
+                            name: "last_name".into(),
                             attribute_type: AttributeType::String,
                             is_list: false,
                             is_visible: true,
@@ -159,7 +160,7 @@ mod tests {
     async fn test_user_attribute_add_and_delete() {
         let fixture = TestFixture::new().await;
         let new_attribute = CreateAttributeRequest {
-            name: "new_attribute".to_owned(),
+            name: "new_attribute".into(),
             attribute_type: AttributeType::Integer,
             is_list: true,
             is_visible: false,
@@ -171,7 +172,7 @@ mod tests {
             .await
             .unwrap();
         let expected_value = AttributeSchema {
-            name: "new_attribute".to_owned(),
+            name: "new_attribute".into(),
             attribute_type: AttributeType::Integer,
             is_list: true,
             is_visible: false,
@@ -188,7 +189,7 @@ mod tests {
             .contains(&expected_value));
         fixture
             .handler
-            .delete_user_attribute("new_attribute")
+            .delete_user_attribute(&"new_attribute".into())
             .await
             .unwrap();
         assert!(!fixture
@@ -205,7 +206,7 @@ mod tests {
     async fn test_group_attribute_add_and_delete() {
         let fixture = TestFixture::new().await;
         let new_attribute = CreateAttributeRequest {
-            name: "new_attribute".to_owned(),
+            name: "NeW_aTTribute".into(),
             attribute_type: AttributeType::JpegPhoto,
             is_list: false,
             is_visible: true,
@@ -217,7 +218,7 @@ mod tests {
             .await
             .unwrap();
         let expected_value = AttributeSchema {
-            name: "new_attribute".to_owned(),
+            name: "new_attribute".into(),
             attribute_type: AttributeType::JpegPhoto,
             is_list: false,
             is_visible: true,
@@ -234,7 +235,7 @@ mod tests {
             .contains(&expected_value));
         fixture
             .handler
-            .delete_group_attribute("new_attribute")
+            .delete_group_attribute(&"new_attriBUte".into())
             .await
             .unwrap();
         assert!(!fixture

--- a/server/src/infra/configuration.rs
+++ b/server/src/infra/configuration.rs
@@ -1,5 +1,5 @@
 use crate::{
-    domain::types::UserId,
+    domain::types::{AttributeName, UserId},
     infra::cli::{GeneralConfigOpts, LdapsOpts, RunOpts, SmtpEncryption, SmtpOpts, TestEmailOpts},
 };
 use anyhow::{Context, Result};
@@ -86,9 +86,9 @@ pub struct Configuration {
     #[builder(default = r#"String::from("sqlite://users.db?mode=rwc")"#)]
     pub database_url: String,
     #[builder(default)]
-    pub ignored_user_attributes: Vec<String>,
+    pub ignored_user_attributes: Vec<AttributeName>,
     #[builder(default)]
-    pub ignored_group_attributes: Vec<String>,
+    pub ignored_group_attributes: Vec<AttributeName>,
     #[builder(default = "false")]
     pub verbose: bool,
     #[builder(default = r#"String::from("server_key")"#)]

--- a/server/src/infra/ldap_server.rs
+++ b/server/src/infra/ldap_server.rs
@@ -2,6 +2,7 @@ use crate::{
     domain::{
         handler::{BackendHandler, LoginHandler},
         opaque_handler::OpaqueHandler,
+        types::AttributeName,
     },
     infra::{
         access_control::AccessControlledBackendHandler,
@@ -72,8 +73,8 @@ async fn handle_ldap_stream<Stream, Backend>(
     stream: Stream,
     backend_handler: Backend,
     ldap_base_dn: String,
-    ignored_user_attributes: Vec<String>,
-    ignored_group_attributes: Vec<String>,
+    ignored_user_attributes: Vec<AttributeName>,
+    ignored_group_attributes: Vec<AttributeName>,
 ) -> Result<Stream>
 where
     Backend: BackendHandler + LoginHandler + OpaqueHandler + 'static,

--- a/server/src/infra/test_utils.rs
+++ b/server/src/infra/test_utils.rs
@@ -45,8 +45,8 @@ mockall::mock! {
     impl SchemaBackendHandler for TestBackendHandler {
         async fn add_user_attribute(&self, request: CreateAttributeRequest) -> Result<()>;
         async fn add_group_attribute(&self, request: CreateAttributeRequest) -> Result<()>;
-        async fn delete_user_attribute(&self, name: &str) -> Result<()>;
-        async fn delete_group_attribute(&self, name: &str) -> Result<()>;
+        async fn delete_user_attribute(&self, name: &AttributeName) -> Result<()>;
+        async fn delete_group_attribute(&self, name: &AttributeName) -> Result<()>;
     }
     #[async_trait]
     impl BackendHandler for TestBackendHandler {}
@@ -74,7 +74,7 @@ pub fn setup_default_schema(mock: &mut MockTestBackendHandler) {
             user_attributes: AttributeList {
                 attributes: vec![
                     AttributeSchema {
-                        name: "avatar".to_owned(),
+                        name: "avatar".into(),
                         attribute_type: AttributeType::JpegPhoto,
                         is_list: false,
                         is_visible: true,
@@ -82,7 +82,7 @@ pub fn setup_default_schema(mock: &mut MockTestBackendHandler) {
                         is_hardcoded: true,
                     },
                     AttributeSchema {
-                        name: "first_name".to_owned(),
+                        name: "first_name".into(),
                         attribute_type: AttributeType::String,
                         is_list: false,
                         is_visible: true,
@@ -90,7 +90,7 @@ pub fn setup_default_schema(mock: &mut MockTestBackendHandler) {
                         is_hardcoded: true,
                     },
                     AttributeSchema {
-                        name: "last_name".to_owned(),
+                        name: "last_name".into(),
                         attribute_type: AttributeType::String,
                         is_list: false,
                         is_visible: true,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,7 +36,7 @@ async fn create_admin_user(handler: &SqlBackendHandler, config: &Configuration) 
     handler
         .create_user(CreateUserRequest {
             user_id: config.ldap_user_dn.clone(),
-            email: config.ldap_user_email.clone(),
+            email: config.ldap_user_email.clone().into(),
             display_name: Some("Administrator".to_string()),
             ..Default::default()
         })
@@ -44,9 +44,7 @@ async fn create_admin_user(handler: &SqlBackendHandler, config: &Configuration) 
         .await
         .context("Error creating admin user")?;
     let groups = handler
-        .list_groups(Some(GroupRequestFilter::DisplayName(
-            "lldap_admin".to_owned(),
-        )))
+        .list_groups(Some(GroupRequestFilter::DisplayName("lldap_admin".into())))
         .await?;
     assert_eq!(groups.len(), 1);
     handler
@@ -57,14 +55,14 @@ async fn create_admin_user(handler: &SqlBackendHandler, config: &Configuration) 
 
 async fn ensure_group_exists(handler: &SqlBackendHandler, group_name: &str) -> Result<()> {
     if handler
-        .list_groups(Some(GroupRequestFilter::DisplayName(group_name.to_owned())))
+        .list_groups(Some(GroupRequestFilter::DisplayName(group_name.into())))
         .await?
         .is_empty()
     {
         warn!("Could not find {} group, trying to create it", group_name);
         handler
             .create_group(CreateGroupRequest {
-                display_name: group_name.to_owned(),
+                display_name: group_name.into(),
                 ..Default::default()
             })
             .await
@@ -94,7 +92,7 @@ async fn set_up_server(config: Configuration) -> Result<ServerBuilder> {
     ensure_group_exists(&backend_handler, "lldap_strict_readonly").await?;
     let admin_present = if let Ok(admins) = backend_handler
         .list_users(
-            Some(UserRequestFilter::MemberOf("lldap_admin".to_owned())),
+            Some(UserRequestFilter::MemberOf("lldap_admin".into())),
             false,
         )
         .await


### PR DESCRIPTION
In addition, group names and emails keep their casing.

Fixes #666 