### PR TITLE
server: Add a check for a changing private key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,8 +1351,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e56602b469b2201400dec66a66aec5a9b8761ee97cd1b8c96ab2483fcc16cc9"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml",
  "uncased",
  "version_check",
@@ -2473,6 +2475,7 @@ dependencies = [
  "clap",
  "cron",
  "derive_builder",
+ "derive_more",
  "figment",
  "figment_file_provider_adapter",
  "futures",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,6 +25,7 @@ base64 = "0.21"
 bincode = "1.3"
 cron = "*"
 derive_builder = "0.12"
+derive_more = "0.99"
 figment_file_provider_adapter = "0.1"
 futures = "*"
 futures-util = "*"
@@ -162,3 +163,7 @@ features = ["file_locks"]
 [dev-dependencies.uuid]
 version = "1"
 features = ["v4"]
+
+[dev-dependencies.figment]
+features = ["test"]
+version = "*"

--- a/server/src/infra/cli.rs
+++ b/server/src/infra/cli.rs
@@ -90,8 +90,12 @@ pub struct RunOpts {
     pub database_url: Option<String>,
 
     /// Force admin password reset to the config value.
-    #[clap(short, long, env = "LLDAP_FORCE_LADP_USER_PASS_RESET")]
+    #[clap(long, env = "LLDAP_FORCE_LADP_USER_PASS_RESET")]
     pub force_ldap_user_pass_reset: Option<bool>,
+
+    /// Force update of the private key after a key change.
+    #[clap(long, env = "LLDAP_FORCE_UPDATE_PRIVATE_KEY")]
+    pub force_update_private_key: Option<bool>,
 
     #[clap(flatten)]
     pub smtp_opts: SmtpOpts,


### PR DESCRIPTION
This checks that the private key used to encode the passwords has not changed since last successful startup, leading to a corruption of all the passwords. Lots of common scenario are covered, with various combinations of key in a file or from a seed, set in the config file or in an env variable or through CLI, and so on.

Fixes #747 