### PR TITLE
server: clean up the attributes, relax the substring filter conditions

### DIFF
--- a/server/src/domain/handler.rs
+++ b/server/src/domain/handler.rs
@@ -83,6 +83,7 @@ pub enum GroupRequestFilter {
     GroupId(GroupId),
     // Check if the group contains a user identified by uid.
     Member(UserId),
+    AttributeEquality(AttributeName, Serialized),
 }
 
 impl From<bool> for GroupRequestFilter {

--- a/server/src/domain/ldap/utils.rs
+++ b/server/src/domain/ldap/utils.rs
@@ -158,12 +158,20 @@ pub fn is_subtree(subtree: &[(String, String)], base_tree: &[(String, String)]) 
 
 pub enum UserFieldType {
     NoMatch,
+    ObjectClass,
+    MemberOf,
+    Dn,
+    EntryDn,
     PrimaryField(UserColumn),
     Attribute(AttributeName, AttributeType, bool),
 }
 
 pub fn map_user_field(field: &AttributeName, schema: &PublicSchema) -> UserFieldType {
     match field.as_str() {
+        "memberof" | "ismemberof" => UserFieldType::MemberOf,
+        "objectclass" => UserFieldType::ObjectClass,
+        "dn" | "distinguishedname" => UserFieldType::Dn,
+        "entrydn" => UserFieldType::EntryDn,
         "uid" | "user_id" | "id" => UserFieldType::PrimaryField(UserColumn::UserId),
         "mail" | "email" => UserFieldType::PrimaryField(UserColumn::Email),
         "cn" | "displayname" | "display_name" => {
@@ -201,16 +209,25 @@ pub enum GroupFieldType {
     NoMatch,
     DisplayName,
     CreationDate,
+    ObjectClass,
+    Dn,
+    // Like Dn, but returned as part of the attributes.
+    EntryDn,
+    Member,
     Uuid,
     Attribute(AttributeName, AttributeType, bool),
 }
 
 pub fn map_group_field(field: &AttributeName, schema: &PublicSchema) -> GroupFieldType {
     match field.as_str() {
-        "cn" | "displayname" | "uid" | "display_name" => GroupFieldType::DisplayName,
+        "dn" | "distinguishedname" => GroupFieldType::Dn,
+        "entrydn" => GroupFieldType::EntryDn,
+        "objectclass" => GroupFieldType::ObjectClass,
+        "cn" | "displayname" | "uid" | "display_name" | "id" => GroupFieldType::DisplayName,
         "creationdate" | "createtimestamp" | "modifytimestamp" | "creation_date" => {
             GroupFieldType::CreationDate
         }
+        "member" | "uniquemember" => GroupFieldType::Member,
         "entryuuid" | "uuid" => GroupFieldType::Uuid,
         _ => schema
             .get_schema()

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -70,6 +70,10 @@ impl RequestFilter {
                     UserFieldType::Attribute(_, _, true) => {
                         Err("Equality not supported for list fields".into())
                     }
+                    UserFieldType::MemberOf => Ok(DomainRequestFilter::MemberOf(eq.value.into())),
+                    UserFieldType::ObjectClass | UserFieldType::Dn | UserFieldType::EntryDn => {
+                        Err("Ldap fields not supported in request filter".into())
+                    }
                 }
             }
             (None, Some(any), None, None, None, None) => Ok(DomainRequestFilter::Or(


### PR DESCRIPTION
This consolidates both user and group attributes in their map_{user,group}_attribute as the only point of parsing. It adds support for custom attribute filters for groups, and makes a SubString filter on an unknown attribute resolve to just false.

It should help with #739 