### PR TITLE
Add user_id for nextcloud example

### DIFF
--- a/example_configs/nextcloud.md
+++ b/example_configs/nextcloud.md
@@ -74,6 +74,7 @@ occ ldap:set-config s01 ldapUserDisplayName displayname
 occ ldap:set-config s01 ldapUserFilterMode 1
 occ ldap:set-config s01 ldapUuidGroupAttribute auto
 occ ldap:set-config s01 ldapUuidUserAttribute auto
+occ ldap:set-config s01 ldapExpertUsernameAttr user_id
 ```
 With a bit of of luck, you should be able to log in your nextcloud instance with LLDAP accounts in the `nextcloud_users` group.
 
@@ -119,6 +120,10 @@ For example:
 (&(|(objectclass=groupOfUniqueNames))(|(cn=family)(cn=friends)))
 ```
 ![groups configuration page](images/nextcloud_groups.png)
+
+### Expert
+
+Set `Internal Username` to `user_id`. This is needed to that the user ID used by Nextcloud corresponds to the `user_id` field and not the `UUID` field.
 
 ## Sharing restrictions
 


### PR DESCRIPTION
Context for why I believe this is a good idea:

- When logging with a new user "ibizaman" through the database backend, the ID used by Nextcloud is `ibizaman`.
- Through the LDAP backend, Nextcloud chooses the `UUID` field.
- Through the SSO backend, integrated with LDAP, Nextcloud chooses `ibizaman`.

I noticed this issue while migrating users from database backend, to LDAP backend, to SSO backend where the ID was inconsistent. Also, it means that if a user was created through LDAP and tries to login through SSO, a new user will be created!

This inconsistency makes no sense IMO. By overriding the `UUID` field to be the `user_id` field, the ID assigned to a new user is consistent whatever the backend used.