### PR TITLE
docs: fix example of ldap dex integration

### DIFF
--- a/example_configs/dex_config.yml
+++ b/example_configs/dex_config.yml
@@ -10,8 +10,7 @@ connectors:
     id: ldap
     name: LDAP
     config:
-      host: lldap-host # make sure it does not start with `ldap://`
-      port: 3890 # or 6360 if you have ldaps enabled
+      host: lldap-host:3890 # or 6360 if you have ldaps enabled, make sure it does not start with `ldap://`
       insecureNoSSL: true # or false if you have ldaps enabled
       insecureSkipVerify: true # or false if you have ldaps enabled
       bindDN: uid=admin,ou=people,dc=example,dc=com # replace admin with your admin user


### PR DESCRIPTION
Host and optional port of the LDAP server in the form "host:port".