### PR TITLE
Improve the package repository section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd
 <details>
 <summary><b>Arch</b></summary>
 <br>
-  Arch Linux offers unofficial support through the <a href="https://wiki.archlinux.org/title/Arch_User_Repository">Arch User Repository (AUR)</a>.<br><br>
+  Arch Linux offers unofficial support through the <a href="https://wiki.archlinux.org/title/Arch_User_Repository">Arch User Repository (AUR)</a>.<br>
+  The package descriptions can be used <a href="https://wiki.archlinux.org/title/Arch_User_Repository#Getting_started">to create and install packages.<br><br>
   Maintainer: <a href="https://github.com/Zepmann">@Zepmann</a><br>
   Support: <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
   Package repository: <a href="https://aur.archlinux.org/packages">Arch user repository</a><br>
@@ -212,7 +213,6 @@ Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd
   </tr>
 </table>
 LLDPA configuration file: /etc/lldap.toml<br>
-The package descriptions can be used [to create and install packages](https://wiki.archlinux.org/title/Arch_User_Repository#Getting_started).<br>
 </details>
 <details>
 <summary><b>Debian</b></summary>

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ from a package repository, officially supported by the distribution or
 community contributed.
 
 Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd#Using_units) `lldap.service` to (auto-)start and stop lldap.
+When using the distributed packages, the default login is `admin/password`. You can change that from the web UI after starting the service.
 
 <details>
 <summary><b>Arch</b></summary>

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd
 <summary><b>Arch</b></summary>
 <br>
   Arch Linux offers unofficial support through the <a href="https://wiki.archlinux.org/title/Arch_User_Repository">Arch User Repository (AUR)</a>.<br>
-  The package descriptions can be used <a href="https://wiki.archlinux.org/title/Arch_User_Repository#Getting_started">to create and install packages.<br><br>
+  The package descriptions can be used <a href="https://wiki.archlinux.org/title/Arch_User_Repository#Getting_started">to create and install packages</a>.<br><br>
   Maintainer: <a href="https://github.com/Zepmann">@Zepmann</a><br>
   Support: <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
   Package repository: <a href="https://aur.archlinux.org/packages">Arch user repository</a><br>

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Depending on the distribution you use, it might be possible to install lldap
 from a package repository, officially supported by the distribution or
 community contributed.
 
-Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd#Using_units) `lldap.service` to (auto-)start and stop lldap.
+Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd#Using_units) `lldap.service` to (auto-)start and stop lldap.<br>
 When using the distributed packages, the default login is `admin/password`. You can change that from the web UI after starting the service.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ LLDPA configuration file: /etc/lldap.toml<br>
 <details>
 <summary><b>Debian</b></summary>
 <br>
-  Unofficial Debian support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Unofficial Debian support is offered through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
   Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
   Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
   Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
@@ -230,7 +230,7 @@ LLDPA configuration file: /etc/lldap.toml<br>
   <tr>
     <td></td>
     <td>lldap-extras</td>
-    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+    <td>Meta-Package for LLDAP and its tools and extensions.</td>
   </tr>
   <tr>
     <td></td>
@@ -245,7 +245,7 @@ LLDPA configuration file: /etc/lldap.toml<br>
   <tr>
     <td></td>
     <td>lldap-cli</td>
-    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+    <td>LLDAP-CLI is an unofficial command line interface for LLDAP.</td>
   </tr>
 </table>
 LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
@@ -253,7 +253,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
 <details>
 <summary><b>CentOS</b></summary>
 <br>
-  Unofficial CentOS support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Unofficial CentOS support is offered through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
   Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
   Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
   Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
@@ -266,7 +266,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-extras</td>
-    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+    <td>Meta-Package for LLDAP and its tools and extensions.</td>
   </tr>
   <tr>
     <td></td>
@@ -281,7 +281,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-cli</td>
-    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+    <td>LLDAP-CLI is an unofficial command line interface for LLDAP.</td>
   </tr>
 </table>
 LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
@@ -289,7 +289,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
 <details>
 <summary><b>Fedora</b></summary>
 <br>
-  Unofficial Fedora support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Unofficial Fedora support is offered through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
   Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
   Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
   Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
@@ -302,7 +302,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-extras</td>
-    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+    <td>Meta-Package for LLDAP and its tools and extensions.</td>
   </tr>
   <tr>
     <td></td>
@@ -317,7 +317,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-cli</td>
-    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+    <td>LLDAP-CLI is an unofficial command line interface for LLDAP.</td>
   </tr>
 </table>
 LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
@@ -325,7 +325,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
 <details>
 <summary><b>OpenSUSE</b></summary>
 <br>
-  Unofficial OpenSUSE support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Unofficial OpenSUSE support is offered through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
   Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
   Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
   Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
@@ -338,7 +338,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-extras</td>
-    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+    <td>Meta-Package for LLDAP and its tools and extensions.</td>
   </tr>
   <tr>
     <td></td>
@@ -353,7 +353,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-cli</td>
-    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+    <td>LLDAP-CLI is an unofficial command line interface for LLDAP.</td>
   </tr>
 </table>
 LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
@@ -361,7 +361,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
 <details>
 <summary><b>Ubuntu</b></summary>
 <br>
-  Unofficial Ubuntu support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Unofficial Ubuntu support is offered through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
   Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
   Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
   Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
@@ -374,7 +374,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-extras</td>
-    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+    <td>Meta-Package for LLDAP and its tools and extensions.</td>
   </tr>
   <tr>
     <td></td>
@@ -389,7 +389,7 @@ LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
   <tr>
     <td></td>
     <td>lldap-cli</td>
-    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+    <td>LLDAP-CLI is an unofficial command line interface for LLDAP.</td>
   </tr>
 </table>
 LLDPA configuration file: /etc/lldap/lldap_config.toml<br>

--- a/README.md
+++ b/README.md
@@ -184,30 +184,216 @@ Depending on the distribution you use, it might be possible to install lldap
 from a package repository, officially supported by the distribution or
 community contributed.
 
-#### Debian, CentOS Fedora, OpenSUSE, Ubuntu
+Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd#Using_units) `lldap.service` to (auto-)start and stop lldap.
 
-The package for these distributions can be found at [LLDAP OBS](https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap).
-- When using the distributed package, the default login is `admin/password`. You can change that from the web UI after starting the service.
-
-#### Arch Linux
-
-Arch Linux offers unofficial support through the [Arch User Repository
-(AUR)](https://wiki.archlinux.org/title/Arch_User_Repository).
-Available package descriptions in AUR are:
-
-- [lldap](https://aur.archlinux.org/packages/lldap) -  Builds the latest stable version.
-- [lldap-bin](https://aur.archlinux.org/packages/lldap-bin) - Uses the latest
-  pre-compiled binaries from the [releases in this repository](https://github.com/lldap/lldap/releases).
-  This package is recommended if you want to run lldap on a system with
-  limited resources.
-- [lldap-git](https://aur.archlinux.org/packages/lldap-git) - Builds the
-  latest main branch code.
-
-The package descriptions can be used
-[to create and install packages](https://wiki.archlinux.org/title/Arch_User_Repository#Getting_started).
-Each package places lldap's configuration file at `/etc/lldap.toml` and offers
-[systemd service](https://wiki.archlinux.org/title/systemd#Using_units)
-`lldap.service` to (auto-)start and stop lldap.
+<details>
+<summary><b>Arch</b></summary>
+<br>
+  Arch Linux offers unofficial support through the <a href="https://wiki.archlinux.org/title/Arch_User_Repository">Arch User Repository (AUR)</a>.<br><br>
+  Maintainer: <a href="https://github.com/Zepmann">@Zepmann</a><br>
+  Support: <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
+  Package repository: <a href="https://aur.archlinux.org/packages">Arch user repository</a><br>
+<table>
+  <tr>
+    <td>Available packages:</td>
+    <td><a href="https://aur.archlinux.org/packages/lldap">lldap</a></td>
+    <td>Builds the latest stable version.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td><a href="https://aur.archlinux.org/packages/lldap-bin">lldap-bin</a></td>
+    <td>Uses the latest pre-compiled binaries from the <a href="https://aur.archlinux.org/packages/lldap-bin">releases in this repository</a>.<br>
+        This package is recommended if you want to run lldap on a system with limited resources.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td><a href="https://aur.archlinux.org/packages/lldap-git">lldap-git</a></td>
+    <td>Builds the latest main branch code.</td>
+  </tr>
+</table>
+LLDPA configuration file: /etc/lldap.toml<br>
+The package descriptions can be used [to create and install packages](https://wiki.archlinux.org/title/Arch_User_Repository#Getting_started).<br>
+</details>
+<details>
+<summary><b>Debian</b></summary>
+<br>
+  Unofficial Debian support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
+  Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
+  Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
+<table>
+  <tr>
+    <td>Available packages:</td>
+    <td>lldap</td>
+    <td>Light LDAP server for authentication.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-extras</td>
+    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-migration-tool</td>
+    <td>CLI migration tool to go from OpenLDAP to LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-set-password</td>
+    <td>CLI tool to set a user password in LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-cli</td>
+    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+  </tr>
+</table>
+LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
+</details>
+<details>
+<summary><b>CentOS</b></summary>
+<br>
+  Unofficial CentOS support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
+  Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
+  Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
+<table>
+  <tr>
+    <td>Available packages:</td>
+    <td>lldap</td>
+    <td>Light LDAP server for authentication.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-extras</td>
+    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-migration-tool</td>
+    <td>CLI migration tool to go from OpenLDAP to LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-set-password</td>
+    <td>CLI tool to set a user password in LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-cli</td>
+    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+  </tr>
+</table>
+LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
+</details>
+<details>
+<summary><b>Fedora</b></summary>
+<br>
+  Unofficial Fedora support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
+  Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
+  Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
+<table>
+  <tr>
+    <td>Available packages:</td>
+    <td>lldap</td>
+    <td>Light LDAP server for authentication.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-extras</td>
+    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-migration-tool</td>
+    <td>CLI migration tool to go from OpenLDAP to LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-set-password</td>
+    <td>CLI tool to set a user password in LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-cli</td>
+    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+  </tr>
+</table>
+LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
+</details>
+<details>
+<summary><b>OpenSUSE</b></summary>
+<br>
+  Unofficial OpenSUSE support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
+  Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
+  Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
+<table>
+  <tr>
+    <td>Available packages:</td>
+    <td>lldap</td>
+    <td>Light LDAP server for authentication.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-extras</td>
+    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-migration-tool</td>
+    <td>CLI migration tool to go from OpenLDAP to LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-set-password</td>
+    <td>CLI tool to set a user password in LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-cli</td>
+    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+  </tr>
+</table>
+LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
+</details>
+<details>
+<summary><b>Ubuntu</b></summary>
+<br>
+  Unofficial Ubuntu support is offerd through the <a href="https://build.opensuse.org/">openSUSE Build Service</a>.<br><br>
+  Maintainer: <a href="https://github.com/Masgalor">@Masgalor</a><br>
+  Support: <a href="https://codeberg.org/Masgalor/LLDAP-Packaging/issues">Codeberg</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
+  Package repository: <a href="https://software.opensuse.org//download.html?project=home%3AMasgalor%3ALLDAP&package=lldap">SUSE openBuildService</a><br>
+<table>
+  <tr>
+    <td>Available packages:</td>
+    <td>lldap</td>
+    <td>Light LDAP server for authentication.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-extras</td>
+    <td>Meta-Package for LLDAP and it's tools and extensions.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-migration-tool</td>
+    <td>CLI migration tool to go from OpenLDAP to LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-set-password</td>
+    <td>CLI tool to set a user password in LLDAP.</td>
+  </tr>
+  <tr>
+    <td></td>
+    <td>lldap-cli</td>
+    <td>LLDAP-CLI is a command line interface for LLDAP.</td>
+  </tr>
+</table>
+LLDPA configuration file: /etc/lldap/lldap_config.toml<br>
+</details>
 
 ### With FreeBSD
 


### PR DESCRIPTION
This PR will extend the `install from a package repository` section to give more information about each individual distro.

Since all prebuilt packages are contributed by third parties (unofficial) the maintainer, support channels, and even the available sub-packages differ for every distro. So I tried to create a meaningful section for every distro that contains all relevant information.

I was not sure who feels responsible for the `Arch` repository, it was added to the readme by @Zepmann , but `AUR` shows another name as the maintainer. For now I listed @Zepmann is maintainer.