### PR TITLE
server: Clarify logging of login attempts and failures

### DIFF
--- a/server/src/domain/error.rs
+++ b/server/src/domain/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
 pub enum DomainError {
-    #[error("Authentication error: `{0}`")]
+    #[error("Authentication error {0}")]
     AuthenticationError(String),
     #[error("Database error: `{0}`")]
     DatabaseError(#[from] sea_orm::DbErr),

--- a/server/src/infra/auth_service.rs
+++ b/server/src/infra/auth_service.rs
@@ -345,6 +345,7 @@ async fn opaque_login_start<Backend>(
 where
     Backend: OpaqueHandler + 'static,
 {
+    info!(r#"OPAQUE login attempt for "{}""#, &request.username);
     data.get_opaque_handler()
         .login_start(request.into_inner())
         .await
@@ -401,11 +402,20 @@ async fn opaque_login_finish<Backend>(
 where
     Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + 'static,
 {
-    let name = data
+    match data
         .get_opaque_handler()
         .login_finish(request.into_inner())
-        .await?;
-    get_login_successful_response(&data, &name).await
+        .await
+    {
+        Ok(name) => {
+            info!(r#"OPAQUE login successful"#);
+            get_login_successful_response(&data, &name).await
+        }
+        Err(e) => {
+            warn!(r#"OPAQUE login attempt failed"#);
+            Err(e.into())
+        }
+    }
 }
 
 async fn opaque_login_finish_handler<Backend>(
@@ -445,31 +455,6 @@ where
     Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + LoginHandler + 'static,
 {
     simple_login(data, request)
-        .await
-        .unwrap_or_else(error_to_http_response)
-}
-
-#[instrument(skip_all, level = "debug", fields(name = %request.name))]
-async fn post_authorize<Backend>(
-    data: web::Data<AppState<Backend>>,
-    request: web::Json<BindRequest>,
-) -> TcpResult<HttpResponse>
-where
-    Backend: TcpBackendHandler + BackendHandler + LoginHandler + 'static,
-{
-    let name = request.name.clone();
-    data.get_login_handler().bind(request.into_inner()).await?;
-    get_login_successful_response(&data, &name).await
-}
-
-async fn post_authorize_handler<Backend>(
-    data: web::Data<AppState<Backend>>,
-    request: web::Json<BindRequest>,
-) -> HttpResponse
-where
-    Backend: TcpBackendHandler + BackendHandler + LoginHandler + 'static,
-{
-    post_authorize(data, request)
         .await
         .unwrap_or_else(error_to_http_response)
 }
@@ -648,32 +633,28 @@ pub fn configure_server<Backend>(cfg: &mut web::ServiceConfig, enable_password_r
 where
     Backend: TcpBackendHandler + LoginHandler + OpaqueHandler + BackendHandler + 'static,
 {
-    cfg.service(web::resource("").route(web::post().to(post_authorize_handler::<Backend>)))
-        .service(
-            web::resource("/opaque/login/start")
-                .route(web::post().to(opaque_login_start::<Backend>)),
-        )
-        .service(
-            web::resource("/opaque/login/finish")
-                .route(web::post().to(opaque_login_finish_handler::<Backend>)),
-        )
-        .service(
-            web::resource("/simple/login").route(web::post().to(simple_login_handler::<Backend>)),
-        )
-        .service(web::resource("/refresh").route(web::get().to(get_refresh_handler::<Backend>)))
-        .service(web::resource("/logout").route(web::get().to(get_logout_handler::<Backend>)))
-        .service(
-            web::scope("/opaque/register")
-                .wrap(CookieToHeaderTranslatorFactory)
-                .service(
-                    web::resource("/start")
-                        .route(web::post().to(opaque_register_start_handler::<Backend>)),
-                )
-                .service(
-                    web::resource("/finish")
-                        .route(web::post().to(opaque_register_finish_handler::<Backend>)),
-                ),
-        );
+    cfg.service(
+        web::resource("/opaque/login/start").route(web::post().to(opaque_login_start::<Backend>)),
+    )
+    .service(
+        web::resource("/opaque/login/finish")
+            .route(web::post().to(opaque_login_finish_handler::<Backend>)),
+    )
+    .service(web::resource("/simple/login").route(web::post().to(simple_login_handler::<Backend>)))
+    .service(web::resource("/refresh").route(web::get().to(get_refresh_handler::<Backend>)))
+    .service(web::resource("/logout").route(web::get().to(get_logout_handler::<Backend>)))
+    .service(
+        web::scope("/opaque/register")
+            .wrap(CookieToHeaderTranslatorFactory)
+            .service(
+                web::resource("/start")
+                    .route(web::post().to(opaque_register_start_handler::<Backend>)),
+            )
+            .service(
+                web::resource("/finish")
+                    .route(web::post().to(opaque_register_finish_handler::<Backend>)),
+            ),
+    );
     if enable_password_reset {
         cfg.service(
             web::resource("/reset/step1/{user_id}")


### PR DESCRIPTION
That way, it becomes doable to automate log monitoring for too many failed login attempts.
Note that OPAQUE logins don't keep the associated username, so they cannot log which user successfully logged in or not; in addition, the client knows between the 2 queries whether the password was correct without having to tell the server.

Sample logs:
- Login through LDAP (failure then success):
```
2024-09-26T18:21:40.971371306+00:00  INFO     LDAP session [ 647ms | 0.06% / 100.00% ]
2024-09-26T18:21:40.971628975+00:00  INFO     ┝━ LDAP request [ 646ms | 99.94% ]
2024-09-26T18:21:40.972371031+00:00  INFO     │  ┝━ ｉ [info]: Login attempt for "admin" | log.target: "lldap::domain::sql_opaque_handler" | log.module_path: "lldap::domain::sql_opaque_handler" | log.file: "server/src/domain/sql_opaque_handler.rs" | log.line: 74
2024-09-26T18:21:41.617956933+00:00  ERROR    │  ┝━ 🚨 [error]:  | error: Authentication protocol error for `Protocol error: `This error results from an error during password verification``
2024-09-26T18:21:41.617998898+00:00  ERROR    │  ┕━ 🚨 [error]:  | error: Authentication error for user "admin"
2024-09-26T18:21:41.618429390+00:00  INFO     ┕━ LDAP request [ 9.67µs | 0.00% ]
2024-09-26T18:21:43.970682921+00:00  INFO     LDAP session [ 642ms | 0.08% / 100.00% ]
2024-09-26T18:21:43.970851846+00:00  INFO     ┝━ LDAP request [ 640ms | 99.65% ]
2024-09-26T18:21:43.971465247+00:00  INFO     │  ┕━ ｉ [info]: Login attempt for "admin" | log.target: "lldap::domain::sql_opaque_handler" | log.module_path: "lldap::domain::sql_opaque_handler" | log.file: "server/src/domain/sql_opaque_handler.rs" | log.line: 74
```
- Login through the simple auth HTTP endpoint (failure then success):
```
2024-09-26T18:21:51.168102497+00:00  INFO     ｉ [info]: Login attempt for "admin" | log.target: "lldap::domain::sql_opaque_handler" | log.module_path: "lldap::domain::sql_opaque_handler" | log.file: "server/src/domain/sql_opaque_handler.rs" | log.line: 74
2024-09-26T18:21:51.803150431+00:00  ERROR    🚨 [error]:  | error: Authentication protocol error for `Protocol error: `This error results from an error during password verification``
2024-09-26T18:21:51.803222676+00:00  ERROR    🚨 [error]:  | error: Authentication error for user "admin"
2024-09-26T18:21:56.405670062+00:00  INFO     ｉ [info]: Login attempt for "admin" | log.target: "lldap::domain::sql_opaque_handler" | log.module_path: "lldap::domain::sql_opaque_handler" | log.file: "server/src/domain/sql_opaque_handler.rs" | log.line: 74
```
- Login through the web UI (silent failure, then success):
```
2024-09-26T18:22:17.512461334+00:00  INFO     ｉ [info]: OPAQUE login attempt for "admin"
2024-09-26T18:22:20.499285134+00:00  INFO     ｉ [info]: OPAQUE login attempt for "admin"
2024-09-26T18:22:20.596530015+00:00  INFO     ｉ [info]: OPAQUE login successful
```