### PR TITLE
server: Add logging for password resets, add name for successful opaque logins

### DIFF
--- a/server/src/domain/sql_opaque_handler.rs
+++ b/server/src/domain/sql_opaque_handler.rs
@@ -9,10 +9,9 @@ use super::{
 use async_trait::async_trait;
 use base64::Engine;
 use lldap_auth::opaque;
-use log::info;
 use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, QuerySelect};
 use secstr::SecUtf8;
-use tracing::{debug, instrument};
+use tracing::{debug, info, instrument, warn};
 
 type SqlOpaqueHandler = SqlBackendHandler;
 
@@ -103,6 +102,7 @@ impl OpaqueHandler for SqlOpaqueHandler {
         request: login::ClientLoginStartRequest,
     ) -> Result<login::ServerLoginStartResponse> {
         let user_id = request.username;
+        info!(r#"OPAQUE login attempt for "{}""#, &user_id);
         let maybe_password_file = self
             .get_password_file_for_user(user_id.clone())
             .await?
@@ -147,9 +147,16 @@ impl OpaqueHandler for SqlOpaqueHandler {
         )?)?;
         // Finish the login: this makes sure the client data is correct, and gives a session key we
         // don't need.
-        let _session_key =
-            opaque::server::login::finish_login(server_login, request.credential_finalization)?
-                .session_key;
+        match opaque::server::login::finish_login(server_login, request.credential_finalization) {
+            Ok(session) => {
+                info!(r#"OPAQUE login successful for "{}""#, &username);
+                let _ = session.session_key;
+            }
+            Err(e) => {
+                warn!(r#"OPAQUE login attempt failed for "{}""#, &username);
+                return Err(e.into());
+            }
+        };
 
         Ok(username)
     }
@@ -191,11 +198,12 @@ impl OpaqueHandler for SqlOpaqueHandler {
             opaque::server::registration::get_password_file(request.registration_upload);
         // Set the user password to the new password.
         let user_update = model::users::ActiveModel {
-            user_id: ActiveValue::Set(username),
+            user_id: ActiveValue::Set(username.clone()),
             password_hash: ActiveValue::Set(Some(password_file.serialize())),
             ..Default::default()
         };
         user_update.update(&self.sql_pool).await?;
+        info!(r#"Successfully (re)set password for "{}""#, &username);
         Ok(())
     }
 }

--- a/server/src/infra/auth_service.rs
+++ b/server/src/infra/auth_service.rs
@@ -345,7 +345,6 @@ async fn opaque_login_start<Backend>(
 where
     Backend: OpaqueHandler + 'static,
 {
-    info!(r#"OPAQUE login attempt for "{}""#, &request.username);
     data.get_opaque_handler()
         .login_start(request.into_inner())
         .await
@@ -407,14 +406,8 @@ where
         .login_finish(request.into_inner())
         .await
     {
-        Ok(name) => {
-            info!(r#"OPAQUE login successful"#);
-            get_login_successful_response(&data, &name).await
-        }
-        Err(e) => {
-            warn!(r#"OPAQUE login attempt failed"#);
-            Err(e.into())
-        }
+        Ok(name) => get_login_successful_response(&data, &name).await,
+        Err(e) => Err(e.into()),
     }
 }
 


### PR DESCRIPTION
Sample logs:
- Reset
```
2024-09-26T20:30:25.928317158+00:00  INFO     ｉ [info]: Successfully (re)set password for "test_user"
```
- OPAQUE (silent) failure, then success:
```
2024-09-26T20:30:56.908559850+00:00  INFO     ｉ [info]: OPAQUE login attempt for "admin"
2024-09-26T20:31:03.074156475+00:00  INFO     ｉ [info]: OPAQUE login attempt for "admin"
2024-09-26T20:31:03.600463950+00:00  INFO     ｉ [info]: OPAQUE login successful for "admin"
```