### PR TITLE
Dockerfile: add jq/jo/curl, required by bootstrap.sh (fix #921)

### DIFF
--- a/.github/workflows/Dockerfile.ci.alpine-base
+++ b/.github/workflows/Dockerfile.ci.alpine-base
@@ -64,7 +64,7 @@ WORKDIR /app
 ENV UID=1000
 ENV GID=1000
 ENV USER=lldap
-RUN apk add --no-cache tini ca-certificates bash tzdata && \
+RUN apk add --no-cache tini ca-certificates bash tzdata jq curl jo && \
     addgroup -g $GID $USER && \
     adduser \
     --disabled-password \

--- a/.github/workflows/Dockerfile.ci.debian-base
+++ b/.github/workflows/Dockerfile.ci.debian-base
@@ -65,7 +65,7 @@ ENV UID=1000
 ENV GID=1000
 ENV USER=lldap
 RUN apt update && \
-    apt install -y --no-install-recommends tini openssl ca-certificates tzdata && \
+    apt install -y --no-install-recommends tini openssl ca-certificates tzdata jq curl jo && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g $GID $USER && useradd --system -m -g $USER --uid $UID $USER && \


### PR DESCRIPTION
fix #921 

Not sure if there is a separate Dockerfile for the rootless variant?