### PR TITLE
fix: typo for first name attribute

### DIFF
--- a/example_configs/keycloak.md
+++ b/example_configs/keycloak.md
@@ -69,4 +69,4 @@ Since Keycloak and LLDAP use different attributes for different parts of a user'
 
 Go back to "User Federation", edit your LDAP integration and click on the "Mappers" tab.
 
-Find or create the "first name" mapper (it should have type `user-attribute-ldap-mapper`) and ensure the "LDAP Attribute" setting is set to `givenname`. Keycloak may have defaulted to `cn` which LLDAP uses for the "Display Name" of a user.
+Find or create the "first name" mapper (it should have type `user-attribute-ldap-mapper`) and ensure the "LDAP Attribute" setting is set to `givenName`. Keycloak may have defaulted to `cn` which LLDAP uses for the "Display Name" of a user.


### PR DESCRIPTION
It should be `givenName` instead of `givenname`. Using the later one, will result in Keycloak bugging out during the sync process, and henceforth displaying an empty user list.