### PR TITLE
server: Only use a single connection with SQlite

### DIFF
--- a/server/src/infra/database_string.rs
+++ b/server/src/infra/database_string.rs
@@ -17,6 +17,12 @@ impl From<&str> for DatabaseUrl {
     }
 }
 
+impl DatabaseUrl {
+    pub fn db_type(&self) -> &str {
+        self.0.scheme()
+    }
+}
+
 impl std::fmt::Debug for DatabaseUrl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.0.password().is_some() {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -82,9 +82,14 @@ async fn ensure_group_exists(handler: &SqlBackendHandler, group_name: &str) -> R
 
 async fn setup_sql_tables(database_url: &DatabaseUrl) -> Result<DatabaseConnection> {
     let sql_pool = {
+        let num_connections = if database_url.db_type() == "sqlite" {
+            1
+        } else {
+            5
+        };
         let mut sql_opt = sea_orm::ConnectOptions::new(database_url.to_string());
         sql_opt
-            .max_connections(5)
+            .max_connections(num_connections)
             .sqlx_logging(true)
             .sqlx_logging_level(log::LevelFilter::Debug);
         Database::connect(sql_opt).await?


### PR DESCRIPTION
Several writer connections can lock the DB and cause other inserts to fail.

A single connection should be enough given the usual workloads

Fixes #1021 