### PR TITLE
Add validation and error/warning messages for attribute names (#1072)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,6 +2536,7 @@ dependencies = [
  "ldap3_proto",
  "lettre",
  "lldap_auth",
+ "lldap_validation",
  "log",
  "mockall",
  "nix",
@@ -2589,6 +2590,7 @@ dependencies = [
  "indexmap 1.6.2",
  "jwt 0.13.0",
  "lldap_auth",
+ "lldap_validation",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2652,6 +2654,10 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "lldap_validation"
+version = "0.6.0"
 
 [[package]]
 name = "local-channel"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -60,6 +60,9 @@ features = [
 path = "../auth"
 features = [ "opaque_client" ]
 
+[dependencies.lldap_validation]
+path = "../validation"
+
 [dependencies.image]
 features = ["jpeg"]
 default-features = false

--- a/app/src/components/create_group_attribute.rs
+++ b/app/src/components/create_group_attribute.rs
@@ -12,6 +12,7 @@ use crate::{
 use anyhow::{bail, Result};
 use gloo_console::log;
 use graphql_client::GraphQLQuery;
+use lldap_validation::attributes::validate_attribute_name;
 use validator_derive::Validate;
 use yew::prelude::*;
 use yew_form_derive::Model;
@@ -62,6 +63,13 @@ impl CommonComponent<CreateGroupAttributeForm> for CreateGroupAttributeForm {
                     bail!("Check the form for errors");
                 }
                 let model = self.form.model();
+                validate_attribute_name(&model.attribute_name).or_else(|invalid_chars| {
+                    let invalid = String::from_iter(invalid_chars);
+                    bail!(
+                        "Attribute name contains one or more invalid characters: {}",
+                        invalid
+                    );
+                })?;
                 let attribute_type = model.attribute_type.parse::<AttributeType>().unwrap();
                 let req = create_group_attribute::Variables {
                     name: model.attribute_name,

--- a/app/src/components/create_user_attribute.rs
+++ b/app/src/components/create_user_attribute.rs
@@ -12,6 +12,7 @@ use crate::{
 use anyhow::{bail, Result};
 use gloo_console::log;
 use graphql_client::GraphQLQuery;
+use lldap_validation::attributes::validate_attribute_name;
 use validator_derive::Validate;
 use yew::prelude::*;
 use yew_form_derive::Model;
@@ -66,6 +67,13 @@ impl CommonComponent<CreateUserAttributeForm> for CreateUserAttributeForm {
                 if model.is_editable && !model.is_visible {
                     bail!("Editable attributes must also be visible");
                 }
+                validate_attribute_name(&model.attribute_name).or_else(|invalid_chars| {
+                    let invalid = String::from_iter(invalid_chars);
+                    bail!(
+                        "Attribute name contains one or more invalid characters: {}",
+                        invalid
+                    );
+                })?;
                 let attribute_type = model.attribute_type.parse::<AttributeType>().unwrap();
                 let req = create_user_attribute::Variables {
                     name: model.attribute_name,

--- a/app/src/components/fragments/attribute_schema.rs
+++ b/app/src/components/fragments/attribute_schema.rs
@@ -1,36 +1,52 @@
+use crate::infra::attributes::AttributeDescription;
+use lldap_validation::attributes::{validate_attribute_name, ALLOWED_CHARACTERS_DESCRIPTION};
 use yew::{html, Html};
 
-use crate::infra::attributes::AttributeDescription;
+fn render_attribute_aliases(attribute_description: &AttributeDescription) -> Html {
+    if attribute_description.aliases.is_empty() {
+        html! {}
+    } else {
+        html! {
+          <>
+            <br/>
+            <small class="text-muted">
+              {"Aliases: "}
+              {attribute_description.aliases.join(", ")}
+            </small>
+          </>
+        }
+    }
+}
+
+fn render_attribute_validation_warnings(attribute_name: &str) -> Html {
+    match validate_attribute_name(attribute_name) {
+        Ok(()) => {
+            html! {}
+        }
+        Err(_invalid_chars) => {
+            html! {
+              <>
+                <br/>
+                <small class="text-warning">
+                  {"Warning: This attribute uses one or more invalid characters "}
+                  {"("}{ALLOWED_CHARACTERS_DESCRIPTION}{"). "}
+                  {"Some clients may not support it."}
+                </small>
+              </>
+            }
+        }
+    }
+}
 
 pub fn render_attribute_name(
     hardcoded: bool,
-    attribute_identifier: &String,
     attribute_description: &AttributeDescription,
 ) -> Html {
-    if hardcoded {
-        html! {
-          <>
-            {&attribute_description.attribute_name}
-            {
-              if attribute_description.aliases.is_empty() {
-                html!{}
-              } else {
-                html!{
-                  <>
-                    <br/>
-                    <small class="text-muted">
-                      {"Aliases: "}
-                      {attribute_description.aliases.join(", ")}
-                    </small>
-                  </>
-                }
-              }
-            }
-          </>
-        }
-    } else {
-        html! {
-          {&attribute_identifier}
-        }
+    html! {
+      <>
+        {&attribute_description.attribute_name}
+        {if hardcoded {render_attribute_aliases(attribute_description)} else {html!{}}}
+        {render_attribute_validation_warnings(attribute_description.attribute_name)}
+      </>
     }
 }

--- a/app/src/components/group_schema_table.rs
+++ b/app/src/components/group_schema_table.rs
@@ -157,7 +157,7 @@ impl GroupSchemaTable {
         let desc = group::resolve_group_attribute_description_or_default(&attribute.name);
         html! {
             <tr key={attribute.name.clone()}>
-                <td>{render_attribute_name(hardcoded, &attribute.name, &desc)}</td>
+                <td>{render_attribute_name(hardcoded, &desc)}</td>
                 <td>{if attribute.is_list { format!("List<{attribute_type}>")} else {attribute_type.to_string()}}</td>
                 <td>{if attribute.is_visible {checkmark.clone()} else {html!{}}}</td>
                 {

--- a/app/src/components/user_schema_table.rs
+++ b/app/src/components/user_schema_table.rs
@@ -156,7 +156,7 @@ impl UserSchemaTable {
         let desc = user::resolve_user_attribute_description_or_default(&attribute.name);
         html! {
             <tr key={attribute.name.clone()}>
-                <td>{render_attribute_name(hardcoded, &attribute.name, &desc)}</td>
+                <td>{render_attribute_name(hardcoded, &desc)}</td>
                 <td>{if attribute.is_list { format!("List<{attribute_type}>")} else {attribute_type.to_string()}}</td>
                 <td>{if attribute.is_editable {checkmark.clone()} else {html!{}}}</td>
                 <td>{if attribute.is_visible {checkmark.clone()} else {html!{}}}</td>

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -85,6 +85,9 @@ version = "0.10.1"
 path = "../auth"
 features = ["opaque_server", "opaque_client", "sea_orm"]
 
+[dependencies.lldap_validation]
+path = "../validation"
+
 [dependencies.opaque-ke]
 version = "0.7"
 

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+authors = ["Simon Broeng Jensen <sbj@cwconsult.dk>"]
+description = "Validation logic for LLDAP"
+edition = "2021"
+homepage = "https://github.com/lldap/lldap"
+license = "GPL-3.0-only"
+name = "lldap_validation"
+repository = "https://github.com/lldap/lldap"
+version = "0.6.0"

--- a/validation/src/attributes.rs
+++ b/validation/src/attributes.rs
@@ -1,0 +1,45 @@
+// Description of allowed characters. Intended for error messages.
+pub const ALLOWED_CHARACTERS_DESCRIPTION: &str = "a-z, A-Z, 0-9, and dash (-)";
+
+pub fn validate_attribute_name(attribute_name: &str) -> Result<(), Vec<char>> {
+    let invalid_chars: Vec<char> = attribute_name
+        .chars()
+        .filter(|c| !(c.is_alphanumeric() || *c == '-'))
+        .collect();
+    if invalid_chars.is_empty() {
+        Ok(())
+    } else {
+        Err(invalid_chars)
+    }
+}
+
+mod tests {
+
+    #[test]
+    fn test_valid_attribute_name() {
+        let valid1: String = "AttrName-01".to_string();
+        let result = super::validate_attribute_name(&valid1);
+        assert!(result == Ok(()));
+    }
+
+    #[test]
+    fn test_invalid_attribute_name_chars() {
+        fn test_invalid_char(c: char) {
+            let prefix: String = "AttrName".to_string();
+            let suffix: String = "01".to_string();
+            let name: String = format!("{prefix}{c}{suffix}");
+            let result = super::validate_attribute_name(&name);
+            match result {
+                Ok(()) => {
+                    panic!()
+                }
+                Err(invalid) => {
+                    assert!(invalid == vec![c.to_owned()]);
+                }
+            }
+        }
+        test_invalid_char(' ');
+        test_invalid_char('_');
+        test_invalid_char('#');
+    }
+}

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -1,0 +1,3 @@
+#![forbid(non_ascii_idents)]
+
+pub mod attributes;


### PR DESCRIPTION
This commit adds support for basic validation of attribute names at creation, and also in the schema overview. Both user and group attributes are validated with the same rules.

For now, attribute names will be considered valid, if they only contain alphanumeric characters.

Validation has been added the following places:

- In graphql API, for creation of both user and group attributes. Request will be rejected, if attribute name is invalid.

- In frontend, before submitting a request to create a new user or group attribute. Rejection here will show an error message including a list of the invalid characters used.

As this change adds stricter validation to attributes, and, since the rationale for this is partly compatibility with other LDAP systems, this change also adds a warning in the schema overviews to any attribute using invalid characters. As this is unfortunately quite a few of the hardcoded attributes, we should probably consider listing other, valid, aliases for the same attributes instead.

# Screenshots

Backend rejecting creation through GraphQL API (frontend validation disabled here for the screenshot):

![backend_rejection](https://github.com/user-attachments/assets/a34773fa-ee29-4c07-bd4b-c989a250f369)

Frontend rejecting creation of invalid attribute pre-submit:

![frontend_rejection](https://github.com/user-attachments/assets/466526f4-407e-4815-9241-2645fab49ab7)

Schema attribute overview showing warnings for potentially problematic attributes:

![overview_warnings](https://github.com/user-attachments/assets/4f0c3ebc-15d6-4604-92ae-2485df7d74ad)
