### PR TITLE
Add support for querying GroupId with LDAP filters

### DIFF
--- a/server/src/domain/ldap/utils.rs
+++ b/server/src/domain/ldap/utils.rs
@@ -245,6 +245,7 @@ pub fn map_user_field(field: &AttributeName, schema: &PublicSchema) -> UserField
 
 pub enum GroupFieldType {
     NoMatch,
+    GroupId,
     DisplayName,
     CreationDate,
     ObjectClass,
@@ -267,6 +268,7 @@ pub fn map_group_field(field: &AttributeName, schema: &PublicSchema) -> GroupFie
         }
         "member" | "uniquemember" => GroupFieldType::Member,
         "entryuuid" | "uuid" => GroupFieldType::Uuid,
+        "group_id" | "groupid" => GroupFieldType::GroupId,
         _ => schema
             .get_schema()
             .group_attributes


### PR DESCRIPTION
Adds support for querying groups by their Id's in LDAP search filters. 

Support is added for both group_id and groupid, the former being shown on the group schema overview, and the latter being supported by openldap's C library, and thus more clients.