### PR TITLE
Change default alias for User & Group schema attributes

### DIFF
--- a/app/src/components/fragments/attribute_schema.rs
+++ b/app/src/components/fragments/attribute_schema.rs
@@ -1,0 +1,36 @@
+use yew::{html, Html};
+
+use crate::infra::attributes::AttributeDescription;
+
+pub fn render_attribute_name(
+    hardcoded: bool,
+    attribute_identifier: &String,
+    attribute_description: &AttributeDescription,
+) -> Html {
+    if hardcoded {
+        html! {
+          <>
+            {&attribute_description.attribute_name}
+            {
+              if attribute_description.aliases.is_empty() {
+                html!{}
+              } else {
+                html!{
+                  <>
+                    <br/>
+                    <small class="text-muted">
+                      {"Aliases: "}
+                      {attribute_description.aliases.join(", ")}
+                    </small>
+                  </>
+                }
+              }
+            }
+          </>
+        }
+    } else {
+        html! {
+          {&attribute_identifier}
+        }
+    }
+}

--- a/app/src/components/fragments/mod.rs
+++ b/app/src/components/fragments/mod.rs
@@ -1,0 +1,1 @@
+pub mod attribute_schema;

--- a/app/src/components/group_schema_table.rs
+++ b/app/src/components/group_schema_table.rs
@@ -1,10 +1,12 @@
 use crate::{
     components::{
         delete_group_attribute::DeleteGroupAttribute,
+        fragments::attribute_schema::render_attribute_name,
         router::{AppRoute, Link},
     },
     convert_attribute_type,
     infra::{
+        attributes::group,
         common_component::{CommonComponent, CommonComponentParts},
         schema::AttributeType,
     },
@@ -152,9 +154,10 @@ impl GroupSchemaTable {
         </svg>
                 };
         let hardcoded = ctx.props().hardcoded;
+        let desc = group::resolve_group_attribute_description_or_default(&attribute.name);
         html! {
             <tr key={attribute.name.clone()}>
-                <td>{&attribute.name}</td>
+                <td>{render_attribute_name(hardcoded, &attribute.name, &desc)}</td>
                 <td>{if attribute.is_list { format!("List<{attribute_type}>")} else {attribute_type.to_string()}}</td>
                 <td>{if attribute.is_visible {checkmark.clone()} else {html!{}}}</td>
                 {

--- a/app/src/components/mod.rs
+++ b/app/src/components/mod.rs
@@ -13,6 +13,7 @@ pub mod delete_group_attribute;
 pub mod delete_user;
 pub mod delete_user_attribute;
 pub mod form;
+pub mod fragments;
 pub mod group_details;
 pub mod group_details_form;
 pub mod group_schema_table;

--- a/app/src/components/user_schema_table.rs
+++ b/app/src/components/user_schema_table.rs
@@ -1,10 +1,12 @@
 use crate::{
     components::{
         delete_user_attribute::DeleteUserAttribute,
+        fragments::attribute_schema::render_attribute_name,
         router::{AppRoute, Link},
     },
     convert_attribute_type,
     infra::{
+        attributes::user,
         common_component::{CommonComponent, CommonComponentParts},
         schema::AttributeType,
     },
@@ -151,9 +153,10 @@ impl UserSchemaTable {
         </svg>
                 };
         let hardcoded = ctx.props().hardcoded;
+        let desc = user::resolve_user_attribute_description_or_default(&attribute.name);
         html! {
             <tr key={attribute.name.clone()}>
-                <td>{&attribute.name}</td>
+                <td>{render_attribute_name(hardcoded, &attribute.name, &desc)}</td>
                 <td>{if attribute.is_list { format!("List<{attribute_type}>")} else {attribute_type.to_string()}}</td>
                 <td>{if attribute.is_editable {checkmark.clone()} else {html!{}}}</td>
                 <td>{if attribute.is_visible {checkmark.clone()} else {html!{}}}</td>

--- a/app/src/infra/attributes.rs
+++ b/app/src/infra/attributes.rs
@@ -1,0 +1,109 @@
+pub struct AttributeDescription<'a> {
+    pub attribute_identifier: &'a str,
+    pub attribute_name: &'a str,
+    pub aliases: Vec<&'a str>,
+}
+
+pub mod group {
+
+    use super::AttributeDescription;
+
+    pub fn resolve_group_attribute_description(name: &str) -> Option<AttributeDescription> {
+        match name {
+            "creation_date" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "creationdate",
+                aliases: vec![name, "createtimestamp", "modifytimestamp"],
+            }),
+            "display_name" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "displayname",
+                aliases: vec![name, "cn", "uid", "id"],
+            }),
+            "group_id" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "groupid",
+                aliases: vec![name],
+            }),
+            "uuid" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: name,
+                aliases: vec!["entryuuid"],
+            }),
+            _ => None,
+        }
+    }
+
+    pub fn resolve_group_attribute_description_or_default(name: &str) -> AttributeDescription {
+        match resolve_group_attribute_description(name) {
+            Some(d) => d,
+            None => AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: name,
+                aliases: vec![],
+            },
+        }
+    }
+}
+
+pub mod user {
+
+    use super::AttributeDescription;
+
+    pub fn resolve_user_attribute_description(name: &str) -> Option<AttributeDescription> {
+        match name {
+            "avatar" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: name,
+                aliases: vec!["jpegphoto"],
+            }),
+            "creation_date" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "creationdate",
+                aliases: vec![name, "createtimestamp", "modifytimestamp"],
+            }),
+            "display_name" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "displayname",
+                aliases: vec![name, "cn"],
+            }),
+            "first_name" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "firstname",
+                aliases: vec![name, "givenname"],
+            }),
+            "last_name" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "lastname",
+                aliases: vec![name, "sn"],
+            }),
+            "mail" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: name,
+                aliases: vec!["email"],
+            }),
+            "user_id" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: "uid",
+                aliases: vec![name, "id"],
+            }),
+            "uuid" => Some(AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: name,
+                aliases: vec!["entryuuid"],
+            }),
+            _ => None,
+        }
+    }
+
+    pub fn resolve_user_attribute_description_or_default(name: &str) -> AttributeDescription {
+        match resolve_user_attribute_description(name) {
+            Some(d) => d,
+            None => AttributeDescription {
+                attribute_identifier: name,
+                attribute_name: name,
+                aliases: vec![],
+            },
+        }
+    }
+}

--- a/app/src/infra/mod.rs
+++ b/app/src/infra/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod attributes;
 pub mod common_component;
 pub mod cookies;
 pub mod form_utils;


### PR DESCRIPTION
A number of the hardcoded attributes displayed in the User and Group schema overviews were using aliases which contain underscores, which is not always completely supported by clients. Therefore, this commit changes the primary alias for each attribute to be one without underscores.

To reduce confusion with this change, and also improve the visibility of available aliases, this commit also includes a list of each alias, for each hardcoded attribute. This list will also include the old primary aliases.

This PR has been marked as a draft, as it depends on somewhat on [PR #1081](https://github.com/lldap/lldap/pull/1081)