### PR TITLE
Fix serving of frontend after PR #1079

### DIFF
--- a/server/src/infra/tcp_server.rs
+++ b/server/src/infra/tcp_server.rs
@@ -95,10 +95,7 @@ async fn main_js_handler<Backend>(
 async fn wasm_handler<Backend>(
     data: web::Data<AppState<Backend>>,
 ) -> actix_web::Result<impl Responder> {
-    Ok(
-        actix_files::NamedFile::open_async(data.assets_path.join("pkg/lldap_app_bg.wasm.gz"))
-            .await?,
-    )
+    Ok(actix_files::NamedFile::open_async(data.assets_path.join("pkg/lldap_app_bg.wasm")).await?)
 }
 
 async fn wasm_handler_compressed<Backend>(


### PR DESCRIPTION
Had changed behaviour to serve the gz compressed wasm package with the uncompressed handler.