### PR TITLE
Cleanup log messages for ignored attribute warnings

### DIFF
--- a/server/src/domain/ldap/group.rs
+++ b/server/src/domain/ldap/group.rs
@@ -82,8 +82,7 @@ pub fn get_group_attribute(
                         attribute,
                         schema,
                     ).or_else(||{warn!(
-                            r#"Ignoring unrecognized group attribute: {}\n\
-                               To disable this warning, add it to "ignored_group_attributes" in the config."#,
+                            r#"Ignoring unrecognized group attribute: {}. To disable this warning, add it to "ignored_group_attributes" in the config."#,
                             attribute
                         );None})?
             }

--- a/server/src/domain/ldap/user.rs
+++ b/server/src/domain/ldap/user.rs
@@ -102,8 +102,7 @@ pub fn get_user_attribute(
                 )
                 .or_else(|| {
                     warn!(
-                        r#"Ignoring unrecognized user attribute: {}\n\
-                      To disable this warning, add it to "ignored_user_attributes" in the config."#,
+                        r#"Ignoring unrecognized user attribute: {}. To disable this warning, add it to "ignored_user_attributes" in the config."#,
                         attribute
                     );
                     None


### PR DESCRIPTION
When debugging lldap logs I recognized that the output looks strange using syslog and grafana.
There are two outputs for each warnings, the first one contains the visible `\n\` sequence.
Additional the user message contains the string ` group attribute` .

Be aware: I've no clue about rust development!