### PR TITLE
server: remove deprecated fields from CreateUserRequest

### DIFF
--- a/crates/domain/src/requests.rs
+++ b/crates/domain/src/requests.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    AttributeName, AttributeType, AttributeValue, Email, GroupId, GroupName, JpegPhoto, UserId,
+    AttributeName, AttributeType, AttributeValue, Email, GroupId, GroupName, UserId,
 };
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone, Default)]
@@ -10,9 +10,6 @@ pub struct CreateUserRequest {
     pub user_id: UserId,
     pub email: Email,
     pub display_name: Option<String>,
-    pub first_name: Option<String>,
-    pub last_name: Option<String>,
-    pub avatar: Option<JpegPhoto>,
     pub attributes: Vec<AttributeValue>,
 }
 
@@ -22,9 +19,6 @@ pub struct UpdateUserRequest {
     pub user_id: UserId,
     pub email: Option<Email>,
     pub display_name: Option<String>,
-    pub first_name: Option<String>,
-    pub last_name: Option<String>,
-    pub avatar: Option<JpegPhoto>,
     pub delete_attributes: Vec<AttributeName>,
     pub insert_attributes: Vec<AttributeValue>,
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -65,10 +65,19 @@ input CreateUserInput {
   id: String!
   email: String
   displayName: String
-  firstName: String
-  lastName: String
-  "Base64 encoded JpegPhoto." avatar: String
-  "User-defined attributes." attributes: [AttributeValueInput!]
+  """
+    First name of user. Deprecated: use attribute instead.
+    If both field and corresponding attribute is supplied, the attribute will take precedence.
+  """ firstName: String
+  """
+    Last name of user. Deprecated: use attribute instead.
+    If both field and corresponding attribute is supplied, the attribute will take precedence.
+  """ lastName: String
+  """
+    Base64 encoded JpegPhoto. Deprecated: use attribute instead.
+    If both field and corresponding attribute is supplied, the attribute will take precedence.
+  """ avatar: String
+  "Attributes." attributes: [AttributeValueInput!]
 }
 
 type AttributeSchema {
@@ -86,9 +95,18 @@ input UpdateUserInput {
   id: String!
   email: String
   displayName: String
-  firstName: String
-  lastName: String
-  "Base64 encoded JpegPhoto." avatar: String
+  """
+    First name of user. Deprecated: use attribute instead.
+    If both field and corresponding attribute is supplied, the attribute will take precedence.
+  """ firstName: String
+  """
+    Last name of user. Deprecated: use attribute instead.
+    If both field and corresponding attribute is supplied, the attribute will take precedence.
+  """ lastName: String
+  """
+    Base64 encoded JpegPhoto. Deprecated: use attribute instead.
+    If both field and corresponding attribute is supplied, the attribute will take precedence.
+  """ avatar: String
   """
     Attribute names to remove.
     They are processed before insertions.

--- a/server/src/domain/sql_backend_handler.rs
+++ b/server/src/domain/sql_backend_handler.rs
@@ -33,7 +33,7 @@ pub mod tests {
     use lldap_auth::{opaque, registration};
     use lldap_domain::{
         requests::{CreateGroupRequest, CreateUserRequest},
-        types::{GroupId, UserId},
+        types::{AttributeValue as DomainAttributeValue, GroupId, Serialized, UserId},
     };
     use pretty_assertions::assert_eq;
     use sea_orm::Database;
@@ -92,9 +92,16 @@ pub mod tests {
                 user_id: UserId::new(name),
                 email: format!("{}@bob.bob", name).into(),
                 display_name: Some("display ".to_string() + name),
-                first_name: Some("first ".to_string() + name),
-                last_name: Some("last ".to_string() + name),
-                ..Default::default()
+                attributes: vec![
+                    DomainAttributeValue {
+                        name: "first_name".into(),
+                        value: Serialized::from(("first ".to_string() + name).as_str()),
+                    },
+                    DomainAttributeValue {
+                        name: "last_name".into(),
+                        value: Serialized::from(("last ".to_string() + name).as_str()),
+                    },
+                ],
             })
             .await
             .unwrap();


### PR DESCRIPTION
The fields first_name, last_name, and avatar have all been moved to regular attributes in the database, and are available through the GraphQL API as such as well. This commit removes the legacy fields for each on the internal CreateUserRequest type, leaving these to only be updateable through attributes.

The fields are still available in the GraphQL CreateUserInput type, preserving backwards compatiblity, and if set, they will be used for the corresponding attribute values. If both fields and attributes are set, the values given through attributes will superceed the fields, and be used. This change also fixes a bug, where creation of a user would fail if either of these attributes were set as both attribute and field, as it would attempt to insert the attribute twice, violating a unique constraint in the database.