### PR TITLE
Add Project Quay example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ folder for help with:
 - [PowerDNS Admin](example_configs/powerdns_admin.md)
 - [Prosody](example_configs/prosody.md)
 - [Proxmox VE](example_configs/proxmox.md)
+- [Quay](example_configs/quay.md)
 - [Radicale](example_configs/radicale.md)
 - [Rancher](example_configs/rancher.md)
 - [Seafile](example_configs/seafile.md)

--- a/example_configs/quay.md
+++ b/example_configs/quay.md
@@ -1,0 +1,26 @@
+# Configuration for Quay
+
+Quay is a container image registry that enables you to build, organize, distribute, and deploy containers.
+
+The official LDAP configuration documentation is located [here](https://docs.projectquay.io/config_quay.html#config-fields-ldap).
+
+For standalone deployments of Project Quay, the core configuration is primarily set through the `config.yaml` file.
+
+If you install Project Quay on OpenShift Container Platform / OKD using the Project Quay Operator, the configuration resides in the `config bundle secret`. 
+
+This example assists with a basic LDAP configuration.
+
+```yaml
+AUTHENTICATION_TYPE: LDAP
+LDAP_ADMIN_DN: cn=admin,ou=people,dc=example,dc=com
+LDAP_ADMIN_PASSWD: password
+LDAP_ALLOW_INSECURE_FALLBACK: false
+LDAP_BASE_DN:
+    - dc=example
+    - dc=com
+LDAP_EMAIL_ATTR: mail
+LDAP_UID_ATTR: uid
+LDAP_URI: ldap://<example_url>
+LDAP_USER_RDN:
+    - ou=people
+```

--- a/example_configs/quay.md
+++ b/example_configs/quay.md
@@ -12,7 +12,7 @@ This example assists with a basic LDAP configuration.
 
 ```yaml
 AUTHENTICATION_TYPE: LDAP
-LDAP_ADMIN_DN: cn=admin,ou=people,dc=example,dc=com
+LDAP_ADMIN_DN: cn=bind_user,ou=people,dc=example,dc=com # The admin DN user must be a member of the lldap_strict_readonly group.
 LDAP_ADMIN_PASSWD: password
 LDAP_ALLOW_INSECURE_FALLBACK: false
 LDAP_BASE_DN:


### PR DESCRIPTION
This PR introduces a basic LDAP configuration for Project Quay deployments.