### PR TITLE
domain: move Permission and ValidationResults to domain crate

### DIFF
--- a/crates/domain/src/access_control.rs
+++ b/crates/domain/src/access_control.rs
@@ -1,0 +1,57 @@
+use lldap_auth::types::UserId;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Permission {
+    Admin,
+    PasswordManager,
+    Readonly,
+    Regular,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationResults {
+    pub user: UserId,
+    pub permission: Permission,
+}
+
+impl ValidationResults {
+    #[cfg(feature = "test")]
+    pub fn admin() -> Self {
+        Self {
+            user: UserId::new("admin"),
+            permission: Permission::Admin,
+        }
+    }
+
+    #[must_use]
+    pub fn is_admin(&self) -> bool {
+        self.permission == Permission::Admin
+    }
+
+    #[must_use]
+    pub fn can_read_all(&self) -> bool {
+        self.permission == Permission::Admin
+            || self.permission == Permission::Readonly
+            || self.permission == Permission::PasswordManager
+    }
+
+    #[must_use]
+    pub fn can_read(&self, user: &UserId) -> bool {
+        self.permission == Permission::Admin
+            || self.permission == Permission::PasswordManager
+            || self.permission == Permission::Readonly
+            || &self.user == user
+    }
+
+    #[must_use]
+    pub fn can_change_password(&self, user: &UserId, user_is_admin: bool) -> bool {
+        self.permission == Permission::Admin
+            || (self.permission == Permission::PasswordManager && !user_is_admin)
+            || &self.user == user
+    }
+
+    #[must_use]
+    pub fn can_write(&self, user: &UserId) -> bool {
+        self.permission == Permission::Admin || &self.user == user
+    }
+}

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod access_control;
 pub mod requests;
 pub mod schema;
 pub mod types;

--- a/server/src/infra/access_control.rs
+++ b/server/src/infra/access_control.rs
@@ -11,6 +11,7 @@ use lldap_domain_handlers::handler::{
 
 use crate::domain::schema::PublicSchema;
 use lldap_domain::{
+    access_control::{Permission, ValidationResults},
     requests::{
         CreateAttributeRequest, CreateGroupRequest, CreateUserRequest, UpdateGroupRequest,
         UpdateUserRequest,
@@ -22,62 +23,6 @@ use lldap_domain::{
     },
 };
 use lldap_domain_model::error::Result;
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Permission {
-    Admin,
-    PasswordManager,
-    Readonly,
-    Regular,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ValidationResults {
-    pub user: UserId,
-    pub permission: Permission,
-}
-
-impl ValidationResults {
-    #[cfg(test)]
-    pub fn admin() -> Self {
-        Self {
-            user: UserId::new("admin"),
-            permission: Permission::Admin,
-        }
-    }
-
-    #[must_use]
-    pub fn is_admin(&self) -> bool {
-        self.permission == Permission::Admin
-    }
-
-    #[must_use]
-    pub fn can_read_all(&self) -> bool {
-        self.permission == Permission::Admin
-            || self.permission == Permission::Readonly
-            || self.permission == Permission::PasswordManager
-    }
-
-    #[must_use]
-    pub fn can_read(&self, user: &UserId) -> bool {
-        self.permission == Permission::Admin
-            || self.permission == Permission::PasswordManager
-            || self.permission == Permission::Readonly
-            || &self.user == user
-    }
-
-    #[must_use]
-    pub fn can_change_password(&self, user: &UserId, user_is_admin: bool) -> bool {
-        self.permission == Permission::Admin
-            || (self.permission == Permission::PasswordManager && !user_is_admin)
-            || &self.user == user
-    }
-
-    #[must_use]
-    pub fn can_write(&self, user: &UserId) -> bool {
-        self.permission == Permission::Admin || &self.user == user
-    }
-}
 
 #[async_trait]
 pub trait UserReadableBackendHandler: ReadSchemaBackendHandler {

--- a/server/src/infra/auth_service.rs
+++ b/server/src/infra/auth_service.rs
@@ -22,7 +22,10 @@ use time::ext::NumericalDuration;
 use tracing::{debug, info, instrument, warn};
 
 use lldap_auth::{login, password_reset, registration, JWTClaims};
-use lldap_domain::types::{GroupDetails, GroupName, UserId};
+use lldap_domain::{
+    access_control::ValidationResults,
+    types::{GroupDetails, GroupName, UserId},
+};
 use lldap_domain_handlers::handler::{
     BackendHandler, BindRequest, LoginHandler, UserRequestFilter,
 };
@@ -31,7 +34,7 @@ use lldap_domain_model::{error::DomainError, model::UserColumn};
 use crate::{
     domain::opaque_handler::OpaqueHandler,
     infra::{
-        access_control::{ReadonlyBackendHandler, UserReadableBackendHandler, ValidationResults},
+        access_control::{ReadonlyBackendHandler, UserReadableBackendHandler},
         tcp_backend_handler::*,
         tcp_server::{error_to_http_response, AppState, TcpError, TcpResult},
     },

--- a/server/src/infra/graphql/api.rs
+++ b/server/src/infra/graphql/api.rs
@@ -1,7 +1,7 @@
 use crate::infra::{
     access_control::{
         AccessControlledBackendHandler, AdminBackendHandler, ReadonlyBackendHandler,
-        UserReadableBackendHandler, UserWriteableBackendHandler, ValidationResults,
+        UserReadableBackendHandler, UserWriteableBackendHandler,
     },
     auth_service::check_if_token_is_valid,
     cli::ExportGraphQLSchemaOpts,
@@ -20,7 +20,7 @@ use juniper::{
     },
     EmptySubscription, FieldError, RootNode, ScalarValue,
 };
-use lldap_domain::types::UserId;
+use lldap_domain::{access_control::ValidationResults, types::UserId};
 use lldap_domain_handlers::handler::BackendHandler;
 use tracing::debug;
 

--- a/server/src/infra/graphql/mutation.rs
+++ b/server/src/infra/graphql/mutation.rs
@@ -783,16 +783,15 @@ fn deserialize_attribute(
 mod tests {
 
     use super::*;
-    use crate::infra::{
-        access_control::{Permission, ValidationResults},
-        graphql::query::Query,
-        test_utils::MockTestBackendHandler,
-    };
+    use crate::infra::{graphql::query::Query, test_utils::MockTestBackendHandler};
     use juniper::{
         execute, graphql_value, DefaultScalarValue, EmptySubscription, GraphQLType, InputValue,
         RootNode, Variables,
     };
-    use lldap_domain::types::{AttributeName, AttributeType};
+    use lldap_domain::{
+        access_control::{Permission, ValidationResults},
+        types::{AttributeName, AttributeType},
+    };
     use mockall::predicate::eq;
     use pretty_assertions::assert_eq;
 

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -786,16 +786,14 @@ impl<Handler: BackendHandler> AttributeValue<Handler> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::infra::{
-        access_control::{Permission, ValidationResults},
-        test_utils::{setup_default_schema, MockTestBackendHandler},
-    };
+    use crate::infra::test_utils::{setup_default_schema, MockTestBackendHandler};
     use chrono::TimeZone;
     use juniper::{
         execute, graphql_value, DefaultScalarValue, EmptyMutation, EmptySubscription, GraphQLType,
         RootNode, Variables,
     };
     use lldap_domain::{
+        access_control::{Permission, ValidationResults},
         schema::{AttributeList, Schema},
         types::{AttributeName, AttributeType, LdapObjectClass},
     };

--- a/server/src/infra/ldap_handler.rs
+++ b/server/src/infra/ldap_handler.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     infra::access_control::{
         AccessControlledBackendHandler, AdminBackendHandler, UserAndGroupListerBackendHandler,
-        UserReadableBackendHandler, ValidationResults,
+        UserReadableBackendHandler,
     },
 };
 use anyhow::Result;
@@ -26,6 +26,7 @@ use ldap3_proto::proto::{
     LdapSearchScope, OID_PASSWORD_MODIFY, OID_WHOAMI,
 };
 use lldap_domain::{
+    access_control::ValidationResults,
     requests::CreateUserRequest,
     types::{Attribute, AttributeName, AttributeType, Email, Group, UserAndGroups, UserId},
 };


### PR DESCRIPTION
Moves the Permission enum and ValidationResults struct to the domain crate.