### PR TITLE
example_configs: Fix nslcd group member mapping.

### DIFF
--- a/example_configs/pam/nslcd.conf
+++ b/example_configs/pam/nslcd.conf
@@ -50,7 +50,7 @@ map passwd homeDirectory "/home/${unix-username}"
 map passwd loginShell unix-shell
 
 map group gidNumber unix-gid
-map group memberUid member
+map group member member
 
 nss_min_uid 1000
 


### PR DESCRIPTION
If a user uses the template nslcd.conf as per the PAM configuration guide group members are not correctly mapped.

Noted when querying groups via `getent group` which was returning `error writing group entry: Invalid argument` for ldap groups with group members.