### PR TITLE
Update mailserver.md

### DIFF
--- a/example_configs/mailserver.md
+++ b/example_configs/mailserver.md
@@ -53,7 +53,7 @@ services:
       - ENABLE_OPENDKIM=0
       - ENABLE_OPENDMARC=0
       # >>> Postfix LDAP Integration
-      - ACCOUNT_PROVISIONER=LDAP
+      - ACCOUNT_PROVISIONER=FILE
       - LDAP_SERVER_HOST=ldap://lldap:3890
       - LDAP_SEARCH_BASE=ou=people,dc=example,dc=com
       - LDAP_BIND_DN=uid=admin,ou=people,dc=example,dc=com


### PR DESCRIPTION
Updated ACCOUNT_PROVISIONER variable in environment directive. Change from ACCOUNT_PROVISIONER=LDAP to ACCOUNT_PROVISIONER=FILE as LDAP provisioning is not fully supported in Dovecot. 