### PR TITLE
example_configs: correct the manual for pkg support in FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Depending on the distribution you use, it might be possible to install lldap
 from a package repository, officially supported by the distribution or
 community contributed.
 
-Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd#Using_units) `lldap.service` to (auto-)start and stop lldap.<br>
+Each package offers a [systemd service](https://wiki.archlinux.org/title/systemd#Using_units) `lldap.service` or [rc.d_lldap](example_configs/freebsd/rc.d_lldap) `rc.d/lldap` to (auto-)start and stop lldap.<br>
 When using the distributed packages, the default login is `admin/password`. You can change that from the web UI after starting the service.
 
 <details>
@@ -419,14 +419,23 @@ LLDAP configuration file: /etc/lldap/lldap_config.toml<br>
 </table>
 LLDAP configuration file: /etc/lldap/lldap_config.toml<br>
 </details>
-
-### With FreeBSD
-
-You can also install it as a rc.d service in FreeBSD, see
-[FreeBSD-install.md](example_configs/freebsd/freebsd-install.md).
-
-The rc.d script file
-[rc.d_lldap](example_configs/freebsd/rc.d_lldap).
+<details>
+<summary><b>FreeBSD</b></summary>
+<br>
+  Official FreeBSD support is offered through the <a href="https://www.freshports.org/">FreeBSD Freshport Build Service</a>.<br><br>
+  Maintainer: <a href="https://github.com/aokblast">@aokblast</a><br>
+  Support: <a href="https://bugs.freebsd.org/bugzilla/">Bugzilla</a>, <a href="https://github.com/lldap/lldap/discussions">Discussions</a><br>
+  Package repository: <a href="https://www.freshports.org/net/lldap/">FreeBSD Freshport Build</a><br>
+  FreeBSD Setup and Migration Manual: <a href="https://github.com/lldap/lldap/blob/main/example_configs/freebsd/freebsd-install.md"> Using FreeBSD </a><br>
+<table>
+  <tr>
+    <td>Available packages:</td>
+    <td>lldap</td>
+    <td>Light LDAP server for authentication.</td>
+  </tr>
+</table>
+LLDAP configuration file: /usr/local/lldap_server/lldap_config.toml<br>
+</details>
 
 ### From source
 

--- a/example_configs/freebsd/freebsd-install.md
+++ b/example_configs/freebsd/freebsd-install.md
@@ -1,3 +1,56 @@
+## Install from Port
+
+Install from Port:
+
+```
+pkg install lldap
+```
+
+Copy the configuration and don't forget to set up:
+
+```
+`cp /usr/local/share/lldap/lldap_config.toml.example /usr/local/lldap_server/lldap_config.toml`
+```
+
+Enable lldap service in /etc/rc.conf:
+
+`sysrc lldap_enable="YES"`
+
+Start your service:
+
+`service lldap start`
+
+## Migrates from Manual Installation:
+
+Backup the database, configuration, and user specified file (like cert):
+```
+cp /usr/local/lldap_server/users.db ./
+cp /usr/local/lldap_server/lldap_config.toml ./
+```
+
+delete all file and install package from port:
+
+```
+rm -rf /usr/local/lldap_server
+pkg install lldap
+```
+
+Move the db and config back:
+
+```
+mv ./users.db /usr/local/lldap_server/ 
+mv ./lldap_config.toml /usr/local/lldap_server/ 
+```
+
+Set the file permission of the twp file to ldap:
+```
+chown ldap:ldap /usr/local/lldap_server/users.db
+chown ldap:ldap /usr/local/lldap_server/lldap_config.toml
+```
+
+
+## Manual Installation (Deprecated)
+
 Extract lldap's [FreeBSD tar.gz](https://github.com/n-connect/rustd-hbbx/blob/main/x86_64-freebsd_lldap-0.5.1.tar.gz) under /usr/local/:
 
 `tar -xvf x86_64-freebsd_lldap-0.5.1.tar.gz -C /usr/local/`
@@ -5,7 +58,7 @@ Extract lldap's [FreeBSD tar.gz](https://github.com/n-connect/rustd-hbbx/blob/ma
 Move rc.d script into the right place:
 `mv /usr/local/lldap_server/rc.d_lldap /usr/local/etc/rc.d/lldap`
 
-Make your config, if your want to enable LDAPS, copy your server key and certification files, and set the owneship (currently www):
+Make your config, if your want to enable LDAPS, copy your server key and certification files, and set the owneship (currently ldap):
 
 `cp /usr/local/lldap_server/lldap_config.docker_template.toml /usr/local/lldap_server/lldap_config..toml`
 

--- a/example_configs/freebsd/rc.d_lldap
+++ b/example_configs/freebsd/rc.d_lldap
@@ -22,6 +22,6 @@ logfile="/var/log/${name}.log"
 
 procname=/usr/local/lldap_server/lldap
 command="/usr/sbin/daemon"
-command_args="-u www -o ${logfile} -t ${name} /usr/local/lldap_server/lldap run"
+command_args="-u ldap -o ${logfile} -t ${name} /usr/local/lldap_server/lldap run"
 
 run_rc_command "$1"


### PR DESCRIPTION
The support in FreeBSD package system should help us on getting rid of downloading tarball.

Here is the corresponding PR in FreeBSD port: https://reviews.freebsd.org/D49986

Still waiting to be approved.