### PR TITLE
Docker Build Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM rust:alpine3.16 AS chef
+FROM rust:alpine3.21 AS chef
 
 RUN set -x \
     # Add user
@@ -41,9 +41,9 @@ RUN cargo build --release -p lldap -p lldap_migration_tool -p lldap_set_password
     && ./app/build.sh
 
 # Final image
-FROM alpine:3.19
+FROM alpine:3.21
 
-ENV GOSU_VERSION 1.14
+ENV GOSU_VERSION=1.14
 # Fetch gosu from git
 RUN set -eux; \
         \


### PR DESCRIPTION
### Context

The Dockerfile currently fails to build the project as the version of rust used in Alpine 3.18/3.19 is no longer supported by many of the dependencies used in LLDAP.

- Update Alpine Version to 3.21
- Migrate Docker `ENV` syntax from deprecated to new style of ENV