### PR TITLE
fix: nextcloud example allows all ldap users to login

### DIFF
--- a/example_configs/nextcloud.md
+++ b/example_configs/nextcloud.md
@@ -45,7 +45,7 @@ occ ldap:set-config s01 ldapBase "dc=example,dc=com"
 occ ldap:set-config s01 ldapBaseUsers "dc=example,dc=com"
 occ ldap:set-config s01 ldapBaseGroups "dc=example,dc=com"
 occ ldap:set-config s01 ldapConfigurationActive 1
-occ ldap:set-config s01 ldapLoginFilter "(&(objectclass=person)(uid=%uid))"
+occ ldap:set-config s01 ldapLoginFilter "(&(&(objectclass=person)(memberOf=cn=nextcloud_users,ou=groups,dc=example,dc=com))(uid=%uid))"
 # EDIT: nextcloud_users group, contains the users who can login to Nextcloud
 occ ldap:set-config s01 ldapUserFilter "(&(objectclass=person)(memberOf=cn=nextcloud_users,ou=groups,dc=example,dc=com))"
 occ ldap:set-config s01 ldapUserFilterMode 0
@@ -105,7 +105,7 @@ You can check with `Verify settings and count users` that your filter is working
 ### Login attributes
 Select `Edit LDAP Query` and enter :
 ```
-(&(objectclass=person)(uid=%uid))
+(&(&(objectclass=person)(memberOf=cn=nextcloud_users,ou=groups,dc=example,dc=com))(uid=%uid))
 ```
 
 ![login attributes page](images/nextcloud_login_attributes.png)


### PR DESCRIPTION
Nextcloud has 2 sections in the LDAP/AD integration app called "Users" and "Login Attributes".

I don't fully understand the difference between the two, however I followed the current lldap nextcloud example and discovered the following security issue...

With the Login Attributes filter set to `(&(objectclass=person)(uid=%uid))` any ldap user (even those that are not in the `nextcloud_users` group) can login to the nextcloud instance and get a fully functioning nextcloud account provisioned.

Even more confusing is that any user that is not part of `nextcloud_users` group that logs into nextcloud, does not show up as a user in the nextcloud administrator portal, making these users almost an invisible user to the nextcloud administrator, but can still login, user the nextcloud services, etc.

The proposed changes add the same filter from the examples "Users" section, to the "Login" section so that only ldap users in the "nextcloud_users" group are allowed to login. 