### PR TITLE
fix(migration): postgres publication require primary key 

### DIFF
--- a/crates/sql-backend-handler/src/sql_migrations.rs
+++ b/crates/sql-backend-handler/src/sql_migrations.rs
@@ -370,10 +370,11 @@ pub(crate) async fn upgrade_to_v1(pool: &DbConnection) -> std::result::Result<()
 
     pool.execute(
         builder.build(
-            Table::create()
-                .table(Metadata::Table)
-                .if_not_exists()
-                .col(ColumnDef::new(Metadata::Version).small_integer()),
+            Table::create().table(Metadata::Table).if_not_exists().col(
+                ColumnDef::new(Metadata::Version)
+                    .small_integer()
+                    .primary_key(),
+            ),
         ),
     )
     .await?;


### PR DESCRIPTION
solving #1194 by making version columns as primary key