### PR TITLE
bootstrap: make password_file a standard custom attribute

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -440,7 +440,7 @@ extract_custom_group_attributes() {
 }
 
 extract_custom_user_attributes() {
-  extract_custom_attributes "$1" '"id","email","password","displayName","firstName","lastName","groups","avatar_file","avatar_url","gravatar_avatar","weserv_avatar"'
+  extract_custom_attributes "$1" '"id","email","password","password_file","displayName","firstName","lastName","groups","avatar_file","avatar_url","gravatar_avatar","weserv_avatar"'
 }
 
 extract_custom_attributes() {


### PR DESCRIPTION
Otherwise the bootstrap script tries to create the password_file as a custom attribute which fails since it's not in the schema. And anyway, it shouldn't be in the schema.