### PR TITLE
Improve bootstrap.sh and documentation for use with Kubernetes

### DIFF
--- a/example_configs/bootstrap/bootstrap.md
+++ b/example_configs/bootstrap/bootstrap.md
@@ -250,7 +250,7 @@ spec:
 
           env:
             - name: LLDAP_URL
-              value: "http://lldap:8080"
+              value: "http://lldap:17170"
 
             - name: LLDAP_ADMIN_USERNAME
               valueFrom: { secretKeyRef: { name: lldap-admin-user, key: username } }
@@ -260,6 +260,9 @@ spec:
 
             - name: DO_CLEANUP
               value: "true"
+
+            - name: LLDAP_FORCE_SET_PASSWORD
+              value: "false"
 
           volumeMounts:
             - name: bootstrap
@@ -288,16 +291,6 @@ spec:
           projected:
             sources:
               - secret:
-                  name: lldap-admin-user
-                  items:
-                    - key: user-config.json
-                      path: admin-config.json
-              - secret:
-                  name: lldap-password-manager-user
-                  items:
-                    - key: user-config.json
-                      path: password-manager-config.json
-              - secret:
                   name: lldap-bootstrap-configs
                   items:
                     - key: user-configs.json
@@ -311,4 +304,15 @@ spec:
                   items:
                     - key: group-configs.json
                       path: group-configs.json
+```
+### Kubernetes config map for bootstrap.sh script
+
+```yaml
+apiVersion: v1
+data:
+  bootstrap.sh: |
+    PASTE CONTENT OF bootstrap.sh HERE
+kind: ConfigMap
+metadata:
+  name: bootstrap
 ```

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,7 +11,7 @@ GROUP_SCHEMAS_DIR="${GROUP_SCHEMAS_DIR:-/bootstrap/group-schemas}"
 USER_CONFIGS_DIR="${USER_CONFIGS_DIR:-/bootstrap/user-configs}"
 GROUP_CONFIGS_DIR="${GROUP_CONFIGS_DIR:-/bootstrap/group-configs}"
 LLDAP_SET_PASSWORD_PATH="${LLDAP_SET_PASSWORD_PATH:-/app/lldap_set_password}"
-LLDAP_FORCE_SET_PASSWORD="${LLDAP_FORCE_SET_PASSWORD:-false}"
+LLDAP_FORCE_SET_PASSWORD="${LLDAP_FORCE_SET_PASSWORD:-true}"
 DO_CLEANUP="${DO_CLEANUP:-false}"
 
 # Fallback to support legacy defaults
@@ -704,12 +704,15 @@ main() {
     done
     printf -- '\n--- %s ---\n' "$id"
 
+    # Save this value before user creation. Will be used to check if password needs to be set/overwritten
+    user_already_exists=$(user_exists "$id")
+
     create_update_user "$id" "$email" "$displayName" "$firstName" "$lastName" "$avatar_file" "$avatar_url" "$gravatar_avatar" "$weserv_avatar"
     redundant_users="$(printf '%s' "$redundant_users" | jq --compact-output --arg id "$id" '. - [$id]')"
 
-    if [[ "$password_file" != 'null' ]] && [[ "$password_file" != '""' ]]; then
+    if [[ "$password_file" != 'null' ]] && [[ "$password_file" != '""' ]] && [[ "$user_already_exists" == 0 || "$LLDAP_FORCE_SET_PASSWORD" == 'true' ]]; then
       LLDAP_USER_PASSWORD="$(cat $password_file)" "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id"
-    elif [[ "$password" != 'null' ]] && [[ "$password" != '""' ]] && [[ "$(user_exists "$id")" == 0 || "$LLDAP_FORCE_SET_PASSWORD" == 'true' ]]; then
+    elif [[ "$password" != 'null' ]] && [[ "$password" != '""' ]] && [[ "$user_already_exists" == 0 || "$LLDAP_FORCE_SET_PASSWORD" == 'true' ]]; then
       "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id" --password "$password"
     fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,6 +11,7 @@ GROUP_SCHEMAS_DIR="${GROUP_SCHEMAS_DIR:-/bootstrap/group-schemas}"
 USER_CONFIGS_DIR="${USER_CONFIGS_DIR:-/bootstrap/user-configs}"
 GROUP_CONFIGS_DIR="${GROUP_CONFIGS_DIR:-/bootstrap/group-configs}"
 LLDAP_SET_PASSWORD_PATH="${LLDAP_SET_PASSWORD_PATH:-/app/lldap_set_password}"
+LLDAP_FORCE_SET_PASSWORD="${LLDAP_FORCE_SET_PASSWORD:-false}"
 DO_CLEANUP="${DO_CLEANUP:-false}"
 
 # Fallback to support legacy defaults
@@ -708,8 +709,8 @@ main() {
 
     if [[ "$password_file" != 'null' ]] && [[ "$password_file" != '""' ]]; then
       LLDAP_USER_PASSWORD="$(cat $password_file)" "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id"
-    elif [[ "$password" != 'null' ]] && [[ "$password" != '""' ]]; then
-      LLDAP_USER_PASSWORD="$password" "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id"
+    elif [[ "$password" != 'null' ]] && [[ "$password" != '""' ]] && [[ "$(user_exists "$id")" == 0 || "$LLDAP_FORCE_SET_PASSWORD" == 'true' ]]; then
+      "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id" --password "$password"
     fi
 
     # Process custom attributes


### PR DESCRIPTION
- Pass `--password` flag to `lldap_set_password` (it doesn't work by passing the ENV variable anymore)
- Add a parameter `LLDAP_FORCE_SET_PASSWORD` to only sync a password once when creating the user. It won't be overwritten afterwards
- Improve documentation for use with Kubernetes (fix Job and add example yaml for config map)