### PR TITLE
devcontainer: Bump Rust version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.74
+FROM rust:1.85
 
 ARG USERNAME=lldapdev
 # We need to keep the user as 1001 to match the GitHub runner's UID.


### PR DESCRIPTION
Bump the Rust toolchain used by the dev container to restore a working development environment.