### PR TITLE
app: Add site_header_label for very basic branding customization

### DIFF
--- a/app/src/components/app.rs
+++ b/app/src/components/app.rs
@@ -44,6 +44,7 @@ pub fn app_container() -> Html {
 
 pub struct App {
     user_info: Option<(String, bool)>,
+    site_header_label: String,
     redirect_to: Option<AppRoute>,
     password_reset_enabled: Option<bool>,
 }
@@ -73,6 +74,7 @@ impl Component for App {
                             None
                         })
                 }),
+            site_header_label: "LLDAP".into(),
             redirect_to: Self::get_redirect_route(ctx),
             password_reset_enabled: None,
         };
@@ -104,6 +106,11 @@ impl Component for App {
             }
             Msg::SettingsReceived(Ok(settings)) => {
                 self.password_reset_enabled = Some(settings.password_reset_enabled);
+                self.site_header_label = settings.site_header_label;
+                let window = web_sys::window().expect("no global `window` exists");
+                let document = window.document().expect("no document exists");
+                let full_title = self.site_header_label.clone() + " Administration";
+                document.set_title(&full_title);
             }
             Msg::SettingsReceived(Err(err)) => {
                 error!(err.to_string());
@@ -119,7 +126,7 @@ impl Component for App {
         let password_reset_enabled = self.password_reset_enabled;
         html! {
           <div>
-            <Banner is_admin={is_admin} username={username} on_logged_out={link.callback(|_| Msg::Logout)} />
+            <Banner is_admin={is_admin} site_header_label={self.site_header_label.clone()} username={username} on_logged_out={link.callback(|_| Msg::Logout)} />
             <div class="container py-3 bg-kug">
               <div class="row justify-content-center" style="padding-bottom: 80px;">
                 <main class="py-3">

--- a/app/src/components/banner.rs
+++ b/app/src/components/banner.rs
@@ -9,6 +9,7 @@ use yew::{Callback, Properties, function_component, html};
 #[derive(Properties, PartialEq)]
 pub struct Props {
     pub is_admin: bool,
+    pub site_header_label: String,
     pub username: Option<String>,
     pub on_logged_out: Callback<()>,
 }
@@ -20,7 +21,7 @@ pub fn banner(props: &Props) -> Html {
         <div class="container">
           <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <a href={yew_router::utils::base_url().unwrap_or("/".to_string())} class="d-flex align-items-center mt-2 mb-lg-0 me-md-5 text-decoration-none">
-              <h2>{"LLDAP"}</h2>
+              <h2>{props.site_header_label.clone()}</h2>
             </a>
 
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">

--- a/crates/frontend-options/src/lib.rs
+++ b/crates/frontend-options/src/lib.rs
@@ -3,4 +3,5 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct Options {
     pub password_reset_enabled: bool,
+    pub site_header_label: String,
 }

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -33,6 +33,9 @@
 ## The public URL of the server, for password reset links.
 #http_url = "http://localhost"
 
+## The name of the service as displayed in the web interface
+#site_header_label = "LLDAP"
+
 ## The path to the front-end assets (relative to the working directory).
 #assets_path = "./app"
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -155,6 +155,10 @@ pub struct RunOpts {
     #[clap(long, env = "LLDAP_HTTP_URL")]
     pub http_url: Option<Url>,
 
+    /// Change web frontend label/brand. Default: "LLDAP"
+    #[clap(long, env = "LLDAP_SITE_HEADER_LABEL")]
+    pub site_header_label: Option<String>,
+
     /// Database connection URL
     #[clap(short, long, env = "LLDAP_DATABASE_URL")]
     pub database_url: Option<DatabaseUrl>,

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -134,6 +134,8 @@ pub struct Configuration {
     pub ldaps_options: LdapsOptions,
     #[builder(default = r#"HttpUrl(Url::parse("http://localhost").unwrap())"#)]
     pub http_url: HttpUrl,
+    #[builder(default = r#"String::from("LLDAP")"#)]
+    pub site_header_label: String,
     #[debug(skip)]
     #[serde(skip)]
     #[builder(field(private), default = "None")]
@@ -434,6 +436,10 @@ impl ConfigOverrider for RunOpts {
 
         if let Some(url) = self.http_url.as_ref() {
             config.http_url = HttpUrl(url.clone());
+        }
+
+        if let Some(site_header_label) = self.site_header_label.as_ref() {
+            config.site_header_label = site_header_label.clone();
         }
 
         if let Some(database_url) = self.database_url.as_ref() {

--- a/server/src/tcp_server.rs
+++ b/server/src/tcp_server.rs
@@ -109,6 +109,7 @@ async fn wasm_handler_compressed<Backend>(
 async fn get_settings<Backend>(data: web::Data<AppState<Backend>>) -> HttpResponse {
     HttpResponse::Ok().json(lldap_frontend_options::Options {
         password_reset_enabled: data.mail_options.enable_password_reset,
+        site_header_label: data.site_header_label.clone(),
     })
 }
 
@@ -120,6 +121,7 @@ fn http_config<Backend>(
     server_url: url::Url,
     assets_path: PathBuf,
     mail_options: MailOptions,
+    site_header_label: String,
 ) where
     Backend: TcpBackendHandler + BackendHandler + LoginHandler + OpaqueHandler + Clone + 'static,
 {
@@ -131,6 +133,7 @@ fn http_config<Backend>(
         server_url,
         assets_path: assets_path.clone(),
         mail_options,
+        site_header_label,
     }))
     .route(
         "/health",
@@ -174,6 +177,7 @@ pub(crate) struct AppState<Backend> {
     pub jwt_blacklist: RwLock<HashSet<u64>>,
     pub server_url: url::Url,
     pub assets_path: PathBuf,
+    pub site_header_label: String,
     pub mail_options: MailOptions,
 }
 
@@ -212,6 +216,7 @@ where
         .await
         .context("while getting the jwt blacklist")?;
     let server_url = config.http_url.0.clone();
+    let site_header_label = config.site_header_label.clone();
     let assets_path = config.assets_path.clone();
     let mail_options = config.smtp_options.clone();
     let verbose = config.verbose;
@@ -231,6 +236,7 @@ where
                 let jwt_secret = jwt_secret.clone();
                 let jwt_blacklist = jwt_blacklist.clone();
                 let server_url = server_url.clone();
+                let site_header_label = site_header_label.clone();
                 let assets_path = assets_path.clone();
                 let mail_options = mail_options.clone();
                 HttpServiceBuilder::default()
@@ -249,6 +255,7 @@ where
                                     server_url,
                                     assets_path,
                                     mail_options,
+                                    site_header_label,
                                 )
                             }),
                         |_| AppConfig::default(),


### PR DESCRIPTION
All this does is add a config option that changes the `<title>` and the header component to read something other than "LLDAP Administration" and "LLDAP" respectively.

I have tested it locally, but I'm not sure what a unit test should look like for this.