### PR TITLE
example config for pocket-id

### DIFF
--- a/example_configs/README.md
+++ b/example_configs/README.md
@@ -51,7 +51,7 @@ configuration files:
 - [Peertube](peertube.md)
 - [Penpot](penpot.md)
 - [pgAdmin](pgadmin.md)
-- [Pocket-Id](pocket-id.md)
+- [Pocket-ID](pocket-id.md)
 - [Portainer](portainer.md)
 - [PowerDNS Admin](powerdns_admin.md)
 - [Prosody](prosody.md)

--- a/example_configs/README.md
+++ b/example_configs/README.md
@@ -51,6 +51,7 @@ configuration files:
 - [Peertube](peertube.md)
 - [Penpot](penpot.md)
 - [pgAdmin](pgadmin.md)
+- [Pocket-Id](pocket-id.md)
 - [Portainer](portainer.md)
 - [PowerDNS Admin](powerdns_admin.md)
 - [Prosody](prosody.md)

--- a/example_configs/pocket-id.md
+++ b/example_configs/pocket-id.md
@@ -1,0 +1,27 @@
+# LLDAP Configuration for Pocket-ID 
+
+[Pocket-ID](https://pocket-id.org/) simple and easy-to-use OIDC provider that allows users to authenticate with their passkeys to your services.
+
+|               |                         | Value                                                       |
+|-----------------------|------------------------------------|-----------------------------------------------------------|
+| **Client Configuration** | LDAP URL                           | ldaps://url:port                               
+|                       | LDAP Bind DN                       | uid=binduser,ou=people,dc=example,dc=com              |
+|                       | LDAP Bind Password                 | password for binduser                      |
+|                       | LDAP Base DN                       | dc=example,dc=com                                         |
+|                       | User Search Filter                 | (objectClass=person)                                      |
+|                       | Groups Search Filter               | (objectClass=groupOfNames)                                |
+|                       | Skip Certificate Verification      | true/false                                                 |
+|                       | Keep disabled users from LDAP      | false                                               |
+| **Attribute Mapping** | User Unique Identifier Attribute   | uuid                                                      |
+|                       | Username Attribute                 | uid                                                       |
+|                       | User Mail Attribute                | mail                                                      |
+|                       | User First Name Attribute          | givenName                                                 |
+|                       | User Last Name Attribute           | sn                                                        |
+|                       | User Profile Picture Attribute     | jpegPhoto                                                 |
+|                       | Group Members Attribute            | member                                                    |
+|                       | Group Unique Identifier Attribute  | uuid                                                      |
+|                       | Group Name Attribute               | cn                                                        |
+|                       | Admin Group Name                   | pocketid_admin_group_name                                            |
+
+
+Save and Sync.

--- a/example_configs/pocket-id.md
+++ b/example_configs/pocket-id.md
@@ -1,6 +1,6 @@
 # LLDAP Configuration for Pocket-ID 
 
-[Pocket-ID](https://pocket-id.org/) simple and easy-to-use OIDC provider that allows users to authenticate with their passkeys to your services.
+[Pocket-ID](https://pocket-id.org/) is a simple, easy-to-use OIDC provider that lets users authenticate to your services using passkeys.
 
 |               |                         | Value                                                       |
 |-----------------------|------------------------------------|-----------------------------------------------------------|


### PR DESCRIPTION
working config for https://pocket-id.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Pocket‑ID example configuration guide for LDAP integration with client settings (LDAP URL, bind DN/password, base DN, search filters, certificate verification, disabled-user handling) and detailed user/group attribute mappings (identifiers, username, email, names, profile picture, group members, admin group). Concludes with “Save and Sync.”
  * Updated example configurations index to include Pocket‑ID.
  * No functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->