### PR TITLE
Update opnsense.md

### DIFF
--- a/example_configs/opnsense.md
+++ b/example_configs/opnsense.md
@@ -92,6 +92,9 @@ Enable the following options on the OPNsense configuration page for your LLDAP s
 - Synchronize groups: `Checked`
 - Automatic user creation: `Checked`
 
+### Constraint Groups
+This limits the groups to prevent injection attacks. If you want to enable this feature, you need to add ou=groups,dc=example,dc=com to the Authentication Containers field. Be sure to separate with a semicolon. Otherwise disable this option.
+
 ### Create OPNsense Group
 
 Go to `System > Access > Groups` and create a new group with the **same** name as the LLDAP group used to authenticate users for OPNsense.


### PR DESCRIPTION
Added instruction for using/not using Constraint Groups. This option is selected by default and the current instructions do not address it, but if it is left on and the Authentication Containers are not updated, the group sync will fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Constraint Groups” section to the OPNsense example configuration.
  * Provides guidance on limiting group scope to reduce injection risks.
  * Instructs how to configure Authentication Containers by adding ou=groups,dc=example,dc=com (separated with a semicolon) or disabling the feature if not needed.
  * Clarifies where this setting appears relative to “Synchronize groups” and “Automatic user creation” to aid setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->