### PR TITLE
chore: upgrade Rust toolchain to 1.89 and modernize code with let-chains

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85
+FROM rust:1.89
 
 ARG USERNAME=lldapdev
 # We need to keep the user as 1001 to match the GitHub runner's UID.

--- a/.github/workflows/Dockerfile.dev
+++ b/.github/workflows/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Keep tracking base image
-FROM rust:1.85-slim-bookworm
+FROM rust:1.89-slim-bookworm
 
 # Set needed env path
 ENV PATH="/opt/armv7l-linux-musleabihf-cross/:/opt/armv7l-linux-musleabihf-cross/bin/:/opt/aarch64-linux-musl-cross/:/opt/aarch64-linux-musl-cross/bin/:/opt/x86_64-linux-musl-cross/:/opt/x86_64-linux-musl-cross/bin/:$PATH"

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-
+  MSRV: "1.89"
 
 ### CI Docs
 
@@ -88,6 +88,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0
+      - name: Install Rust
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: "${{ env.MSRV }}"
+            targets: "wasm32-unknown-unknown"
       - uses: actions/cache@v4
         with:
           path: |
@@ -99,8 +105,6 @@ jobs:
           key: lldap-ui-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             lldap-ui-
-      - name: Add wasm target (rust)
-        run: rustup target add wasm32-unknown-unknown
       - name: Install wasm-pack with cargo
         run: cargo install wasm-pack || true
         env:
@@ -133,6 +137,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0
+      - name: Install Rust
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: "${{ env.MSRV }}"
+            targets: "${{ matrix.target }}"
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MSRV: 1.85.0
+  MSRV: "1.89"
 
 jobs:
   pre_job:
@@ -42,7 +42,7 @@ jobs:
             toolchain: "${{ env.MSRV }}"
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build --verbose --workspace
+        run: cargo +${{steps.toolchain.outputs.name}} build --verbose --workspace
       - name: Run tests
         run: cargo +${{steps.toolchain.outputs.name}} test --verbose --workspace
       - name: Generate GraphQL schema

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2024"
 homepage = "https://github.com/lldap/lldap"
 license = "GPL-3.0-only"
 repository = "https://github.com/lldap/lldap"
+rust-version = "1.89"
 
 [profile.release]
 lto = true

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/app/src/components/form/file_input.rs
+++ b/app/src/components/form/file_input.rs
@@ -147,20 +147,18 @@ impl Component for JpegFileInput {
                 true
             }
             Msg::FileLoaded(file_name, data) => {
-                if let Some(avatar) = &mut self.avatar {
-                    if let Some(file) = &avatar.file {
-                        if file.name() == file_name {
-                            if let Result::Ok(data) = data {
-                                if !is_valid_jpeg(data.as_slice()) {
-                                    // Clear the selection.
-                                    self.avatar = Some(JsFile::default());
-                                    // TODO: bail!("Chosen image is not a valid JPEG");
-                                } else {
-                                    avatar.contents = Some(data);
-                                    return true;
-                                }
-                            }
-                        }
+                if let Some(avatar) = &mut self.avatar
+                    && let Some(file) = &avatar.file
+                    && file.name() == file_name
+                    && let Result::Ok(data) = data
+                {
+                    if !is_valid_jpeg(data.as_slice()) {
+                        // Clear the selection.
+                        self.avatar = Some(JsFile::default());
+                        // TODO: bail!("Chosen image is not a valid JPEG");
+                    } else {
+                        avatar.contents = Some(data);
+                        return true;
                     }
                 }
                 self.reader = None;

--- a/app/src/infra/attributes.rs
+++ b/app/src/infra/attributes.rs
@@ -8,7 +8,7 @@ pub mod group {
 
     use super::AttributeDescription;
 
-    pub fn resolve_group_attribute_description(name: &str) -> Option<AttributeDescription> {
+    pub fn resolve_group_attribute_description(name: &str) -> Option<AttributeDescription<'_>> {
         match name {
             "creation_date" => Some(AttributeDescription {
                 attribute_identifier: name,
@@ -39,7 +39,7 @@ pub mod group {
         }
     }
 
-    pub fn resolve_group_attribute_description_or_default(name: &str) -> AttributeDescription {
+    pub fn resolve_group_attribute_description_or_default(name: &str) -> AttributeDescription<'_> {
         match resolve_group_attribute_description(name) {
             Some(d) => d,
             None => AttributeDescription {
@@ -55,7 +55,7 @@ pub mod user {
 
     use super::AttributeDescription;
 
-    pub fn resolve_user_attribute_description(name: &str) -> Option<AttributeDescription> {
+    pub fn resolve_user_attribute_description(name: &str) -> Option<AttributeDescription<'_>> {
         match name {
             "avatar" => Some(AttributeDescription {
                 attribute_identifier: name,
@@ -111,7 +111,7 @@ pub mod user {
         }
     }
 
-    pub fn resolve_user_attribute_description_or_default(name: &str) -> AttributeDescription {
+    pub fn resolve_user_attribute_description_or_default(name: &str) -> AttributeDescription<'_> {
         match resolve_user_attribute_description(name) {
             Some(d) => d,
             None => AttributeDescription {

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2,6 +2,7 @@
 #![forbid(non_ascii_idents)]
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::let_unit_value)]
+#![allow(clippy::unnecessary_operation)] // Doesn't work well with the html macro.
 
 pub mod components;
 pub mod infra;

--- a/crates/access-control/Cargo.toml
+++ b/crates/access-control/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 tracing = "*"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["opaque_server", "opaque_client"]

--- a/crates/domain-handlers/Cargo.toml
+++ b/crates/domain-handlers/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [features]
 test = []

--- a/crates/domain-model/Cargo.toml
+++ b/crates/domain-model/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [features]
 test = []

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [features]
 test = []

--- a/crates/frontend-options/Cargo.toml
+++ b/crates/frontend-options/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies.serde]
 workspace = true

--- a/crates/graphql-server/Cargo.toml
+++ b/crates/graphql-server/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "*"

--- a/crates/ldap/Cargo.toml
+++ b/crates/ldap/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "*"

--- a/crates/ldap/src/search.rs
+++ b/crates/ldap/src/search.rs
@@ -291,12 +291,12 @@ pub fn make_ldap_subschema_entry(schema: PublicSchema) -> LdapOp {
 }
 
 pub(crate) fn is_root_dse_request(request: &LdapSearchRequest) -> bool {
-    if request.base.is_empty() && request.scope == LdapSearchScope::Base {
-        if let LdapFilter::Present(attribute) = &request.filter {
-            if attribute.eq_ignore_ascii_case("objectclass") {
-                return true;
-            }
-        }
+    if request.base.is_empty()
+        && request.scope == LdapSearchScope::Base
+        && let LdapFilter::Present(attribute) = &request.filter
+        && attribute.eq_ignore_ascii_case("objectclass")
+    {
+        return true;
     }
     false
 }

--- a/crates/opaque-handler/Cargo.toml
+++ b/crates/opaque-handler/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [features]
 test = []

--- a/crates/sql-backend-handler/Cargo.toml
+++ b/crates/sql-backend-handler/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [features]
 test = []

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true

--- a/migration-tool/Cargo.toml
+++ b/migration-tool/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "*"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.89"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 actix = "0.13"

--- a/server/tests/common/graphql.rs
+++ b/server/tests/common/graphql.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::common::env;
 use anyhow::{Context, Result, anyhow};
 use graphql_client::GraphQLQuery;

--- a/set-password/Cargo.toml
+++ b/set-password/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- Upgrades Rust from 1.85 to 1.89 across Docker files, CI workflows, and MSRV
- Adds `rust-toolchain.toml` to pin project toolchain version
- Modernizes code with let-chain syntax replacing nested if-let patterns
- Updates lifetime annotations in attribute description functions