### PR TITLE
chore: add Nix flake-based development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ recipe.json
 lldap_config.toml
 cert.pem
 key.pem
+
+# Nix
+result
+result-*
+.direnv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,9 @@ advanced guides (scripting, migrations, ...) you can contribute to.
 ### Code
 
 If you don't know what to start with, check out the 
-[good first issues](https://github.com/lldap/lldap/labels/good%20first%20issue). 
+[good first issues](https://github.com/lldap/lldap/labels/good%20first%20issue).
+
+For an alternative development environment setup, see [docs/nix-development.md](docs/nix-development.md). 
 
 Otherwise, if you want to fix a specific bug or implement a feature, make sure
 to start by creating an issue for it (if it doesn't already exist). There, we

--- a/docs/nix-development.md
+++ b/docs/nix-development.md
@@ -1,0 +1,71 @@
+# Nix Development Environment
+
+LLDAP provides a Nix flake that sets up a complete development environment with all necessary tools and dependencies.
+
+## Requirements
+
+- [Nix](https://nixos.org/download.html) with flakes enabled
+- (Optional) [direnv](https://direnv.net/) for automatic environment activation
+
+## Usage
+
+```bash
+# Clone the repository
+git clone https://github.com/lldap/lldap.git
+cd lldap
+
+# Enter the development environment
+nix develop
+
+# Build the workspace
+cargo build --workspace
+
+# Run tests
+cargo test --workspace
+
+# Check formatting and linting
+cargo fmt --check --all
+cargo clippy --tests --workspace -- -D warnings
+
+# Build frontend
+./app/build.sh
+
+# Export GraphQL schema (if needed)
+./export_schema.sh
+
+# Start development server
+cargo run -- run --config-file lldap_config.docker_template.toml
+```
+
+## Building with Nix
+
+You can also build LLDAP directly using Nix:
+
+```bash
+# Build the default package (server)
+nix build
+
+# Build and run
+nix run
+```
+
+## Development Shells
+
+The flake provides two development shells:
+
+- `default` - Full development environment
+- `ci` - Minimal environment similar to CI
+
+```bash
+# Use the CI-like environment
+nix develop .#ci
+```
+
+## Automatic Environment Activation (Optional)
+
+For automatic environment activation when entering the project directory:
+
+1. Install direnv: `nix profile install nixpkgs#direnv`
+2. Set up direnv shell hook in your shell configuration 
+3. Navigate to the project directory and allow direnv: `direnv allow`
+4. The environment will automatically activate when entering the directory

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1757183466,
+        "narHash": "sha256-kTdCCMuRE+/HNHES5JYsbRHmgtr+l9mOtf5dpcMppVc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d599ae4847e7f87603e7082d73ca673aa93c916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1757730403,
+        "narHash": "sha256-Jxl4OZRVsXs8JxEHUVQn3oPu6zcqFyGGKaFrlNgbzp0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3232f7f8bd07849fc6f4ae77fe695e0abb2eba2c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,162 @@
+{
+  description = "LLDAP - Light LDAP implementation for authentication";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        # MSRV from the project
+        rustVersion = "1.89.0";
+        
+        # Rust toolchain with required components
+        rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
+          extensions = [ "rust-src" "clippy" "rustfmt" ];
+          targets = [ 
+            "wasm32-unknown-unknown" 
+            "x86_64-unknown-linux-musl"
+            "aarch64-unknown-linux-musl" 
+            "armv7-unknown-linux-musleabihf"
+          ];
+        };
+
+        craneLib = crane.lib.${system}.overrideToolchain rustToolchain;
+
+        # Common build inputs
+        nativeBuildInputs = with pkgs; [
+          # Rust toolchain and tools
+          rustToolchain
+          wasm-pack
+          
+          # Build tools
+          pkg-config
+          
+          # Compression and utilities
+          gzip
+          curl
+          wget
+          
+          # Development tools
+          git
+          jq
+          
+          # Cross-compilation support
+          gcc
+        ];
+
+        buildInputs = with pkgs; [
+          # System libraries that might be needed
+          openssl
+          sqlite
+        ] ++ lib.optionals stdenv.isDarwin [
+          # macOS specific dependencies
+          darwin.apple_sdk.frameworks.Security
+          darwin.apple_sdk.frameworks.SystemConfiguration
+        ];
+
+        # Environment variables
+        commonEnvVars = {
+          CARGO_TERM_COLOR = "always";
+          RUST_BACKTRACE = "1";
+          
+          # Cross-compilation environment
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/cc";
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsCross.aarch64-multiplatform.stdenv.cc}/bin/aarch64-unknown-linux-gnu-gcc";
+          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER = "${pkgs.pkgsCross.armv7l-hf-multiplatform.stdenv.cc}/bin/arm-unknown-linux-gnueabihf-gcc";
+        };
+
+
+
+      in
+      {
+        # Development shells
+        devShells = {
+          default = pkgs.mkShell ({
+            inherit nativeBuildInputs buildInputs;
+            
+            shellHook = ''
+              echo "🔐 LLDAP Development Environment"
+              echo "==============================================="
+              echo "Rust version: ${rustVersion}"
+              echo "Standard cargo commands available:"
+              echo "  cargo build --workspace    - Build the workspace"
+              echo "  cargo test --workspace     - Run tests"
+              echo "  cargo clippy --tests --workspace -- -D warnings - Run linting"
+              echo "  cargo fmt --check --all    - Check formatting"
+              echo "  ./app/build.sh              - Build frontend WASM"
+              echo "  ./export_schema.sh          - Export GraphQL schema"
+              echo "==============================================="
+              echo ""
+              
+              # Ensure wasm-pack is available
+              if ! command -v wasm-pack &> /dev/null; then
+                echo "⚠️  wasm-pack not found in PATH"
+              fi
+              
+              # Check if we're in the right directory
+              if [[ "$(git rev-parse --show-toplevel 2>/dev/null)" == "$PWD" ]]; then
+                echo "⚠️  Run this from the project root directory"
+              fi
+            '';
+          } // commonEnvVars);
+
+          # Minimal shell for CI-like environment
+          ci = pkgs.mkShell ({
+            inherit nativeBuildInputs buildInputs;
+            
+            shellHook = ''
+              echo "🤖 LLDAP CI Environment"
+              echo "Running with Rust ${rustVersion}"
+            '';
+          } // commonEnvVars);
+        };
+
+        # Package outputs (optional - for building with Nix)
+        packages = {
+          default = craneLib.buildPackage {
+            src = craneLib.cleanCargoSource (craneLib.path ./.);
+            
+            inherit nativeBuildInputs buildInputs;
+            
+            # Build only the server by default
+            cargoExtraArgs = "-p lldap";
+            
+            # Skip tests in the package build
+            doCheck = false;
+            
+            meta = with pkgs.lib; {
+              description = "Light LDAP implementation for authentication";
+              homepage = "https://github.com/lldap/lldap";
+              license = licenses.gpl3Only;
+              maintainers = with maintainers; [ ];
+              platforms = platforms.unix;
+            };
+          };
+        };
+
+        # Formatter for the flake itself
+        formatter = pkgs.nixpkgs-fmt;
+
+        # Apps for running via `nix run`
+        apps = {
+          default = flake-utils.lib.mkApp {
+            drv = self.packages.${system}.default;
+          };
+        };
+      });
+}


### PR DESCRIPTION
- Add Nix flake and lockfile for reproducible development environments
- Document Nix-based setup in `docs/nix-development.md`
- Add `.envrc` for direnv integration and update `.gitignore` for Nix/direnv artifacts
- Reference Nix setup in CONTRIBUTING.md