### PR TITLE
auth: serialize exp and iat claims as NumericDate to comply with RFC7519

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.5+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,10 +2314,11 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2438,7 +2451,7 @@ dependencies = [
  "thiserror 1.0.66",
  "tokio-util",
  "tracing",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2532,7 +2545,7 @@ dependencies = [
  "futures-util",
  "graphql_client 0.11.0",
  "hmac 0.12.1",
- "http 0.2.12",
+ "http 1.1.0",
  "juniper",
  "jwt 0.16.0",
  "ldap3",
@@ -2581,7 +2594,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
- "uuid 1.11.0",
+ "uuid 1.18.1",
  "webpki-roots 0.22.6",
 ]
 
@@ -2649,6 +2662,7 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "thiserror 2.0.12",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2669,7 +2683,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "strum 0.25.0",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2687,7 +2701,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_bytes",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2706,7 +2720,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror 2.0.12",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2739,7 +2753,7 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2763,7 +2777,7 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "tracing",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2837,7 +2851,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -2853,7 +2867,7 @@ dependencies = [
  "lldap_opaque_handler",
  "mockall",
  "tracing",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -3542,6 +3556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,7 +4043,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "url",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -4049,7 +4069,7 @@ dependencies = [
  "chrono",
  "inherent",
  "ordered-float",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -4061,7 +4081,7 @@ dependencies = [
  "chrono",
  "sea-query",
  "sqlx",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -4419,7 +4439,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.11.0",
+ "uuid 1.18.1",
  "webpki-roots 0.26.8",
 ]
 
@@ -4502,7 +4522,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.12",
  "tracing",
- "uuid 1.11.0",
+ "uuid 1.18.1",
  "whoami",
 ]
 
@@ -4541,7 +4561,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.12",
  "tracing",
- "uuid 1.11.0",
+ "uuid 1.18.1",
  "whoami",
 ]
 
@@ -4567,7 +4587,7 @@ dependencies = [
  "sqlx-core",
  "tracing",
  "url",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -4956,7 +4976,7 @@ dependencies = [
  "mutually_exclusive_features",
  "pin-project",
  "tracing",
- "uuid 1.11.0",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -5163,13 +5183,16 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "atomic",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
+ "js-sys",
  "md-5",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5273,6 +5296,24 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.5+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasite"
@@ -5610,6 +5651,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "x509-parser"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -24,6 +24,7 @@ generic-array = "0.14"
 rand = "0.8"
 sha2 = "0.9"
 thiserror = "2"
+uuid = { version = "1.18.1", features = ["serde"] }
 
 [dependencies.derive_more]
 features = ["debug", "display"]

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -208,7 +208,9 @@ pub mod types {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct JWTClaims {
+    #[serde(with = "chrono::serde::ts_seconds")]
     pub exp: DateTime<Utc>,
+    #[serde(with = "chrono::serde::ts_seconds")]
     pub iat: DateTime<Utc>,
     pub user: String,
     pub groups: HashSet<String>,

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -4,6 +4,7 @@ use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
+use uuid::Uuid;
 
 pub mod access_control;
 pub mod opaque;
@@ -212,6 +213,7 @@ pub struct JWTClaims {
     pub exp: DateTime<Utc>,
     #[serde(with = "chrono::serde::ts_seconds")]
     pub iat: DateTime<Utc>,
+    pub jti: Uuid,
     pub user: String,
     pub groups: HashSet<String>,
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -136,7 +136,7 @@ features = ["full"]
 version = "1.25"
 
 [dependencies.uuid]
-features = ["v1", "v3"]
+features = ["v1", "v3", "v4"]
 version = "1"
 
 [dependencies.tracing-forest]

--- a/server/src/auth_service.rs
+++ b/server/src/auth_service.rs
@@ -35,6 +35,7 @@ use std::{
 };
 use time::ext::NumericalDuration;
 use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
 
 type Token<S> = jwt::Token<jwt::Header, JWTClaims, S>;
 type SignedToken = Token<jwt::token::Signed>;
@@ -56,6 +57,7 @@ async fn create_jwt<Handler: TcpBackendHandler>(
     let claims = JWTClaims {
         exp: Utc::now() + chrono::Duration::days(1),
         iat: Utc::now(),
+        jti: Uuid::new_v4(),
         user: user.to_string(),
         groups: groups
             .into_iter()


### PR DESCRIPTION
I'm trying to use lldap as a JWT issuer in a homelab SSO (handrolled with a bit of Lua for openresty). The `lua-resty-jwt` library won't validate lldap's JWT, giving `'exp' is malformed.  Expected to be a positive numeric value.` as a reason.

lldap serializes `exp` and `iat` as RFC3339 strings (chrono's default):

```
$ echo $token | cut -d. -f2 | base64 -d | jq .
{
  "exp": "2025-09-14T19:51:45.153970837Z",
  "iat": "2025-09-13T19:51:45.153971045Z",
  "user": "psentee",
  "groups": [
    "lldap_admin",
    "humans"
  ]
}
```

[RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4) specifies that `exp`, `iat`, `nbf` timestamps "MUST be a number containing a NumericDate value", "NumericDate" being seconds since epoch (UNIX time) as a JSON numeric value. This means that `lua-resty-jwt` is right.

With this change, timestamp claims are serialized in the correct format, and JWT passes `lua-resty-jwt`'s validation:

```
$ echo $token | cut -d. -f2 | base64 -d | jq .
{
  "exp": 1757929329,
  "iat": 1757842929,
  "user": "psentee",
  "groups": [
    "humans",
    "lldap_admin"
  ]
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tokens now include a unique JWT ID (jti) for improved tracking and revocation.

- **Bug Fixes**
  - Standardizes JWT exp and iat timestamps to Unix epoch seconds for better compatibility with validators and libraries.
  - Reduces token parse/validation failures caused by non-numeric timestamp formats.

- **Notes**
  - Newly issued tokens use numeric timestamps and include a jti; consumers may need to adjust validation or storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->