### PR TITLE
Modify group membership and filter attributes to be correct for portainer description

### DIFF
--- a/example_configs/portainer.md
+++ b/example_configs/portainer.md
@@ -56,9 +56,15 @@ ou=groups,dc=example,dc=com
 ```
 #### Group Membership Attribute
 ```
-cn
+uniqueMember
 ```
 #### Group Filter 
+Is optional:
 ```
-is optional
+(objectClass=groupofuniquenames)
 ```
+
+## Admin group search configurations 
+
+Use the same configurations as above to grant each users admin rights in their respective teams.
+You can then also fetch all groups, and select which groups have universal admin rights.


### PR DESCRIPTION
Updated group membership and filter attributes in portainer.md The current descriptions is wrong, and will make portainer try to assign "group" to be a member of "group" instead of the assign the "user" to be a part of "group"