### PR TITLE
feat(server): add native HTTPS support for the web interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,7 +2858,6 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest 0.11.27",
  "reqwest 0.12.28",
  "rustls 0.23.35",
  "rustls-pemfile 2.2.0",
@@ -4161,14 +4160,12 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -5895,19 +5892,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,6 +2859,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "rustls 0.23.35",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -4160,12 +4161,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.4",
 ]
@@ -5892,6 +5895,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/docs/install.md
+++ b/docs/install.md
@@ -76,7 +76,7 @@ services:
       # - LLDAP_LDAPS_OPTIONS__ENABLED=true
       # - LLDAP_LDAPS_OPTIONS__CERT_FILE=/path/to/certfile.crt
       # - LLDAP_LDAPS_OPTIONS__KEY_FILE=/path/to/keyfile.key
-      # If using HTTPS, set enable true and configure cert and key path you can also change https port access
+      # If using HTTPS, set enabled true and configure cert and key path. You can also change the HTTPS port.
       # - LLDAP_HTTPS_OPTIONS__ENABLED=true
       # - LLDAP_HTTPS_OPTIONS__PORT=17174 # It's a default value, so put it just if you want to edit port
       # - LLDAP_HTTPS_OPTIONS__CERT_FILE=/path/to/certfile.crt

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,7 +42,7 @@ Example for docker compose:
 - You can generate the secrets by running `./generate_secrets.sh`
 
 ```yaml
-version: "3"
+---
 
 volumes:
   lldap_data:
@@ -53,11 +53,13 @@ services:
     image: lldap/lldap:stable
     ports:
       # For LDAP, not recommended to expose, see Usage section.
-      #- "3890:3890"
+      # - "3890:3890"
       # For LDAPS (LDAP Over SSL), enable port if LLDAP_LDAPS_OPTIONS__ENABLED set true, look env below
-      #- "6360:6360"
-      # For the web front-end
+      # - "6360:6360"
+      # For HTTP web front-end (setup a reverse proxy and firewall rule if you want to setup this methode)
       - "17170:17170"
+      # For HTTPS web front-end.
+      # - "17174:17174"
     volumes:
       - "lldap_data:/data"
       # Alternatively, you can mount a local folder
@@ -74,6 +76,11 @@ services:
       # - LLDAP_LDAPS_OPTIONS__ENABLED=true
       # - LLDAP_LDAPS_OPTIONS__CERT_FILE=/path/to/certfile.crt
       # - LLDAP_LDAPS_OPTIONS__KEY_FILE=/path/to/keyfile.key
+      # If using HTTPS, set enable true and configure cert and key path you can also change https port access
+      # - LLDAP_HTTPS_OPTIONS__ENABLED=true
+      # - LLDAP_HTTPS_OPTIONS__PORT=17174 # It's a default value, so put it just if you want to edit port
+      # - LLDAP_HTTPS_OPTIONS__CERT_FILE=/path/to/certfile.crt
+      # - LLDAP_HTTPS_OPTIONS__KEY_FILE=/path/to/keyfile.key
       # You can also set a different database:
       # - LLDAP_DATABASE_URL=mysql://mysql-user:password@mysql-server/my-database
       # - LLDAP_DATABASE_URL=postgres://postgres-user:password@postgres-server/my-database

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -160,6 +160,16 @@ key_seed = "RanD0m STR1ng"
 ## Certificate key file.
 #key_file="/data/key.pem"
 
+[https_options]
+## Whether to enable HTTPS.
+#enabled=true
+## Port on which to listen.
+#port=17174
+## Certificate file.
+#cert_file="/data/cert.pem"
+## Certificate key file.
+#key_file="/data/key.pem"
+
 ## Options to configure the healthcheck command.
 ## To set these options from environment variables, use the following format
 ## (example with http_host): LLDAP_HEALTHCHECK_OPTIONS__HTTP_HOST

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -173,7 +173,7 @@ features = [
 [dependencies.reqwest]
 version = "0.12"
 default-features = false
-features = ["rustls-tls-webpki-roots", "json", "stream"]
+features = ["rustls-tls-webpki-roots"]
 
 [dependencies.url]
 version = "2"
@@ -211,7 +211,7 @@ path = "../crates/sql-backend-handler"
 features = ["test"]
 
 [dev-dependencies.reqwest]
-version = "*"
+version = "0.12"
 default-features = false
 features = ["json", "blocking", "rustls-tls"]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -171,9 +171,9 @@ features = [
 ]
 
 [dependencies.reqwest]
-version = "0.11"
+version = "0.12"
 default-features = false
-features = ["rustls-tls-webpki-roots"]
+features = ["rustls-tls-webpki-roots", "json", "stream"]
 
 [dependencies.url]
 version = "2"

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -176,6 +176,9 @@ pub struct RunOpts {
     pub ldaps_opts: LdapsOpts,
 
     #[clap(flatten)]
+    pub https_opts: HttpsOpts,
+
+    #[clap(flatten)]
     pub healthcheck_opts: HealthcheckOpts,
 }
 
@@ -210,6 +213,26 @@ pub struct LdapsOpts {
     /// Ldaps certificate key file. Default: key.pem
     #[clap(long, env = "LLDAP_LDAPS_OPTIONS__KEY_FILE")]
     pub ldaps_key_file: Option<String>,
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(next_help_heading = Some("HTTPS"))]
+pub struct HttpsOpts {
+    /// Enable HTTP TLS (HTTPS). Default: false.
+    #[clap(long, env = "LLDAP_HTTPS_OPTIONS__ENABLED")]
+    pub https_enabled: Option<bool>,
+
+    /// HTTPS port. Default: 17174
+    #[clap(long, env = "LLDAP_HTTPS_OPTIONS__PORT")]
+    pub https_port: Option<u16>,
+
+    /// HTTPS certificate file. Default: cert.pem
+    #[clap(long, env = "LLDAP_HTTPS_OPTIONS__CERT_FILE")]
+    pub https_cert_file: Option<String>,
+
+    /// HTTPS key file. Default: key.pem
+    #[clap(long, env = "LLDAP_HTTPS_OPTIONS__KEY_FILE")]
+    pub https_key_file: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, clap::ValueEnum)]

--- a/server/src/healthcheck.rs
+++ b/server/src/healthcheck.rs
@@ -1,4 +1,4 @@
-use crate::{configuration::LdapsOptions, tls};
+use crate::{configuration::HttpsOptions, configuration::LdapsOptions, tls};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use futures_util::SinkExt;
 use ldap3_proto::{
@@ -186,10 +186,40 @@ pub async fn check_ldaps(host: &str, ldaps_options: &LdapsOptions) -> Result<()>
 }
 
 #[instrument(level = "info", err)]
-pub async fn check_api(host: &str, port: u16) -> Result<()> {
-    reqwest::get(format!("http://{host}:{port}/health"))
-        .await?
-        .error_for_status()?;
-    info!("Success");
+pub async fn check_http(host: &str, port: u16) -> Result<()> {
+    let url = format!("http://{host}:{port}/health");
+    let client = reqwest::Client::new();
+
+    let res = client.get(&url).send().await?;
+    res.error_for_status()?;
+    info!("Success (HTTP)");
+    Ok(())
+}
+
+#[instrument(skip_all, level = "info", err, fields(host = %host, port = %https_options.port))]
+pub async fn check_https(host: &str, https_options: &HttpsOptions) -> Result<()> {
+    if !https_options.enabled {
+        info!("HTTPS not enabled");
+        return Ok(());
+    }
+
+    let port = https_options.port;
+    let url = format!("https://{host}:{port}/health");
+    let certs = tls::load_certificates(&https_options.cert_file)?;
+
+    let target_cert_der = certs
+        .first()
+        .ok_or_else(|| anyhow!("Certificate file is empty"))?;
+
+    let reqwest_cert = reqwest::Certificate::from_der(target_cert_der.as_ref())
+        .context("Failed to convert certificate for HTTP client")?;
+
+    let client = reqwest::Client::builder()
+        .add_root_certificate(reqwest_cert)
+        .build()?;
+
+    let res = client.get(&url).send().await?;
+    res.error_for_status()?;
+    info!("Success (HTTPS)");
     Ok(())
 }

--- a/server/src/healthcheck.rs
+++ b/server/src/healthcheck.rs
@@ -216,6 +216,7 @@ pub async fn check_https(host: &str, https_options: &HttpsOptions) -> Result<()>
 
     let client = reqwest::Client::builder()
         .add_root_certificate(reqwest_cert)
+        .danger_accept_invalid_hostnames(true)
         .build()?;
 
     let res = client.get(&url).send().await?;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -264,10 +264,14 @@ async fn run_healthcheck(opts: RunOpts) -> Result<()> {
             delay,
             healthcheck::check_ldaps(&config.healthcheck_options.ldap_host, &config.ldaps_options)
         ),
-        timeout(
-            delay,
-            healthcheck::check_http(&config.healthcheck_options.http_host, config.http_port)
-        ),
+        timeout(delay, async {
+            if config.https_options.enabled {
+                Ok(())
+            } else {
+                healthcheck::check_http(&config.healthcheck_options.http_host, config.http_port)
+                    .await
+            }
+        }),
         timeout(
             delay,
             healthcheck::check_https(&config.healthcheck_options.http_host, &config.https_options)


### PR DESCRIPTION
This commit enables the web server to run natively over HTTPS, allowing secure deployments without requiring a reverse proxy.

Key changes:
- Configuration: Added `[https_options]` to config and CLI arguments (port, cert/key paths, enabled flag).
- Server: Updated `tcp_server.rs` to support binding with TLS.
- Healthcheck: Added `check_https` which uses certificate pinning to verify identity.
- Main: Updated healthcheck runner to check HTTP and HTTPS endpoints concurrently.
- Docs: Updated `install.md` and `lldap_config.docker_template.toml` with HTTPS configuration examples.