### PR TITLE
fix: prevent attributes with conflicting types across users/groups

### DIFF
--- a/crates/sql-backend-handler/src/sql_schema_backend_handler.rs
+++ b/crates/sql-backend-handler/src/sql_schema_backend_handler.rs
@@ -29,6 +29,23 @@ impl ReadSchemaBackendHandler for SqlBackendHandler {
 #[async_trait]
 impl SchemaBackendHandler for SqlBackendHandler {
     async fn add_user_attribute(&self, request: CreateAttributeRequest) -> Result<()> {
+        // Check for conflicting group attribute with the same name but different type.
+        let schema = self.get_schema().await?;
+        if let Some(group_attr) = schema
+            .group_attributes
+            .attributes
+            .iter()
+            .find(|a| a.name == request.name)
+        {
+            if group_attr.attribute_type != request.attribute_type {
+                return Err(DomainError::InternalError(format!(
+                    "A group attribute '{}' already exists with type {:?}, \
+                     cannot create a user attribute with type {:?}. \
+                     LDAP requires each attribute name to have a single type.",
+                    request.name, group_attr.attribute_type, request.attribute_type
+                )));
+            }
+        }
         let new_attribute = model::user_attribute_schema::ActiveModel {
             attribute_name: Set(request.name),
             attribute_type: Set(request.attribute_type),
@@ -42,6 +59,23 @@ impl SchemaBackendHandler for SqlBackendHandler {
     }
 
     async fn add_group_attribute(&self, request: CreateAttributeRequest) -> Result<()> {
+        // Check for conflicting user attribute with the same name but different type.
+        let schema = self.get_schema().await?;
+        if let Some(user_attr) = schema
+            .user_attributes
+            .attributes
+            .iter()
+            .find(|a| a.name == request.name)
+        {
+            if user_attr.attribute_type != request.attribute_type {
+                return Err(DomainError::InternalError(format!(
+                    "A user attribute '{}' already exists with type {:?}, \
+                     cannot create a group attribute with type {:?}. \
+                     LDAP requires each attribute name to have a single type.",
+                    request.name, user_attr.attribute_type, request.attribute_type
+                )));
+            }
+        }
         let new_attribute = model::group_attribute_schema::ActiveModel {
             attribute_name: Set(request.name),
             attribute_type: Set(request.attribute_type),

--- a/crates/sql-backend-handler/src/sql_schema_backend_handler.rs
+++ b/crates/sql-backend-handler/src/sql_schema_backend_handler.rs
@@ -29,62 +29,80 @@ impl ReadSchemaBackendHandler for SqlBackendHandler {
 #[async_trait]
 impl SchemaBackendHandler for SqlBackendHandler {
     async fn add_user_attribute(&self, request: CreateAttributeRequest) -> Result<()> {
-        // Check for conflicting group attribute with the same name but different type.
-        let schema = self.get_schema().await?;
-        if let Some(group_attr) = schema
-            .group_attributes
-            .attributes
-            .iter()
-            .find(|a| a.name == request.name)
-        {
-            if group_attr.attribute_type != request.attribute_type {
-                return Err(DomainError::InternalError(format!(
-                    "A group attribute '{}' already exists with type {:?}, \
-                     cannot create a user attribute with type {:?}. \
-                     LDAP requires each attribute name to have a single type.",
-                    request.name, group_attr.attribute_type, request.attribute_type
-                )));
-            }
-        }
-        let new_attribute = model::user_attribute_schema::ActiveModel {
-            attribute_name: Set(request.name),
-            attribute_type: Set(request.attribute_type),
-            is_list: Set(request.is_list),
-            is_user_visible: Set(request.is_visible),
-            is_user_editable: Set(request.is_editable),
-            is_hardcoded: Set(false),
-        };
-        new_attribute.insert(&self.sql_pool).await?;
+        self.sql_pool
+            .transaction::<_, (), DomainError>(|transaction| {
+                Box::pin(async move {
+                    // Check for conflicting group attribute with the same name but different type.
+                    // Done inside the transaction to prevent TOCTOU races.
+                    let schema =
+                        Self::get_schema_with_transaction(transaction).await?;
+                    if let Some(group_attr) = schema
+                        .group_attributes
+                        .attributes
+                        .iter()
+                        .find(|a| a.name == request.name)
+                    {
+                        if group_attr.attribute_type != request.attribute_type {
+                            return Err(DomainError::InternalError(format!(
+                                "A group attribute '{}' already exists with type {:?}, \
+                                 cannot create a user attribute with type {:?}. \
+                                 LDAP requires each attribute name to have a single type.",
+                                request.name, group_attr.attribute_type, request.attribute_type
+                            )));
+                        }
+                    }
+                    let new_attribute = model::user_attribute_schema::ActiveModel {
+                        attribute_name: Set(request.name),
+                        attribute_type: Set(request.attribute_type),
+                        is_list: Set(request.is_list),
+                        is_user_visible: Set(request.is_visible),
+                        is_user_editable: Set(request.is_editable),
+                        is_hardcoded: Set(false),
+                    };
+                    new_attribute.insert(transaction).await?;
+                    Ok(())
+                })
+            })
+            .await?;
         Ok(())
     }
 
     async fn add_group_attribute(&self, request: CreateAttributeRequest) -> Result<()> {
-        // Check for conflicting user attribute with the same name but different type.
-        let schema = self.get_schema().await?;
-        if let Some(user_attr) = schema
-            .user_attributes
-            .attributes
-            .iter()
-            .find(|a| a.name == request.name)
-        {
-            if user_attr.attribute_type != request.attribute_type {
-                return Err(DomainError::InternalError(format!(
-                    "A user attribute '{}' already exists with type {:?}, \
-                     cannot create a group attribute with type {:?}. \
-                     LDAP requires each attribute name to have a single type.",
-                    request.name, user_attr.attribute_type, request.attribute_type
-                )));
-            }
-        }
-        let new_attribute = model::group_attribute_schema::ActiveModel {
-            attribute_name: Set(request.name),
-            attribute_type: Set(request.attribute_type),
-            is_list: Set(request.is_list),
-            is_group_visible: Set(request.is_visible),
-            is_group_editable: Set(request.is_editable),
-            is_hardcoded: Set(false),
-        };
-        new_attribute.insert(&self.sql_pool).await?;
+        self.sql_pool
+            .transaction::<_, (), DomainError>(|transaction| {
+                Box::pin(async move {
+                    // Check for conflicting user attribute with the same name but different type.
+                    // Done inside the transaction to prevent TOCTOU races.
+                    let schema =
+                        Self::get_schema_with_transaction(transaction).await?;
+                    if let Some(user_attr) = schema
+                        .user_attributes
+                        .attributes
+                        .iter()
+                        .find(|a| a.name == request.name)
+                    {
+                        if user_attr.attribute_type != request.attribute_type {
+                            return Err(DomainError::InternalError(format!(
+                                "A user attribute '{}' already exists with type {:?}, \
+                                 cannot create a group attribute with type {:?}. \
+                                 LDAP requires each attribute name to have a single type.",
+                                request.name, user_attr.attribute_type, request.attribute_type
+                            )));
+                        }
+                    }
+                    let new_attribute = model::group_attribute_schema::ActiveModel {
+                        attribute_name: Set(request.name),
+                        attribute_type: Set(request.attribute_type),
+                        is_list: Set(request.is_list),
+                        is_group_visible: Set(request.is_visible),
+                        is_group_editable: Set(request.is_editable),
+                        is_hardcoded: Set(false),
+                    };
+                    new_attribute.insert(transaction).await?;
+                    Ok(())
+                })
+            })
+            .await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Prevents creating user and group attributes with the same name but different types. LDAP requires each attribute name to have a single associated type (RFC 4512).

## Why this matters

Currently, creating a "foo" attribute as String for users and Integer for groups succeeds silently. When the LDAP schema is generated, the attribute appears twice with different types, which violates the LDAP spec and confuses clients.

## Changes

`crates/sql-backend-handler/src/sql_schema_backend_handler.rs`:

- `add_user_attribute`: Before inserting, queries `get_schema()` and checks if a group attribute with the same name has a different type. Returns `DomainError::InternalError` if types conflict.
- `add_group_attribute`: Same cross-check against existing user attributes.

When the types match, the attribute is created normally (deduplication in LDAP schema generation is a separate concern).

## Testing

- Creating "foo" as String for both users and groups: succeeds (same type)
- Creating "foo" as String for users, then Integer for groups: returns error
- Creating "foo" as Integer for groups, then Integer for users: succeeds (same type)
- Existing attributes without conflicts: no behavior change

Partial fix for #1202 (validation at creation time; LDAP schema deduplication and startup warnings are future work)

This contribution was developed with AI assistance (Claude Code).