### PR TITLE
auth: Add trusted header authentication with IP allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2660,6 +2663,8 @@ dependencies = [
  "futures-util",
  "graphql_client",
  "hmac 0.12.1",
+ "http 1.4.0",
+ "ipnet",
  "juniper",
  "jwt",
  "ldap3",

--- a/app/src/components/logout.rs
+++ b/app/src/components/logout.rs
@@ -1,9 +1,9 @@
 use crate::infra::{
     api::HostService,
     common_component::{CommonComponent, CommonComponentParts},
-    cookies::delete_cookie,
+    cookies::{delete_cookie, get_cookie},
 };
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use yew::prelude::*;
 
 pub struct LogoutButton {
@@ -28,12 +28,26 @@ impl CommonComponent<LogoutButton> for LogoutButton {
     ) -> Result<bool> {
         match msg {
             Msg::LogoutRequested => {
-                self.common
-                    .call_backend(ctx, HostService::logout(), Msg::LogoutCompleted);
+                if let Some(redirect_url) = get_cookie("trusted_header_logout_url")? {
+                    delete_cookie("user_id")?;
+                    delete_cookie("is_admin")?;
+                    let _ = delete_cookie("trusted_header_logout_url");
+
+                    web_sys::window()
+                        .ok_or_else(|| anyhow!("Could not access browser window"))?
+                        .location()
+                        .set_href(&redirect_url)
+                        .map_err(|_| anyhow!("Could not redirect to logout URL"))?;
+                } else {
+                    self.common
+                        .call_backend(ctx, HostService::logout(), Msg::LogoutCompleted);
+                }
             }
             Msg::LogoutCompleted(res) => {
                 res?;
                 delete_cookie("user_id")?;
+                delete_cookie("is_admin")?;
+                let _ = delete_cookie("trusted_header_logout_url");
                 ctx.props().on_logged_out.emit(());
             }
         }

--- a/app/src/infra/api.rs
+++ b/app/src/infra/api.rs
@@ -1,4 +1,4 @@
-use super::cookies::set_cookie;
+use super::cookies::{delete_cookie, set_cookie, set_session_cookie};
 use anyhow::{Context, Result, anyhow};
 use gloo_net::http::{Method, RequestBuilder};
 use graphql_client::GraphQLQuery;
@@ -80,10 +80,28 @@ async fn call_server_empty_response_with_error_message<Body: Serialize>(
 fn set_cookies_from_jwt(response: login::ServerLoginResponse) -> Result<(String, bool)> {
     let jwt_claims = get_claims_from_jwt(response.token.as_str()).context("Could not parse JWT")?;
     let is_admin = jwt_claims.groups.contains("lldap_admin");
+    let _ = delete_cookie("trusted_header_logout_url");
     set_cookie("user_id", &jwt_claims.user, &jwt_claims.exp)
         .map(|_| set_cookie("is_admin", &is_admin.to_string(), &jwt_claims.exp))
         .map(|_| (jwt_claims.user.clone(), is_admin))
         .context("Error setting cookie")
+}
+
+fn extract_user_info_from_auth_response(
+    response: login::ServerAuthResponse,
+) -> Result<(String, bool)> {
+    match response {
+        login::ServerAuthResponse::Token(token_response) => set_cookies_from_jwt(token_response),
+        login::ServerAuthResponse::TrustedHeader(header_response) => {
+            let logout_url = header_response
+                .logout_url
+                .unwrap_or_else(|| base_url() + "/login");
+            let _ = delete_cookie("user_id");
+            let _ = delete_cookie("is_admin");
+            set_session_cookie("trusted_header_logout_url", &logout_url)?;
+            Ok((header_response.user_id, header_response.is_admin))
+        }
+    }
 }
 
 impl HostService {
@@ -170,13 +188,13 @@ impl HostService {
     }
 
     pub async fn refresh() -> Result<(String, bool)> {
-        call_server_json_with_error_message::<login::ServerLoginResponse, _>(
+        call_server_json_with_error_message::<login::ServerAuthResponse, _>(
             &(base_url() + "/auth/refresh"),
             GET_REQUEST,
             "Could not start authentication: ",
         )
         .await
-        .and_then(set_cookies_from_jwt)
+        .and_then(extract_user_info_from_auth_response)
     }
 
     // The `_request` parameter is to make it the same shape as the other functions.

--- a/app/src/infra/cookies.rs
+++ b/app/src/infra/cookies.rs
@@ -13,23 +13,28 @@ fn get_document() -> Result<HtmlDocument> {
         })
 }
 
-pub fn set_cookie(cookie_name: &str, value: &str, expiration: &DateTime<Utc>) -> Result<()> {
-    let doc = web_sys::window()
-        .and_then(|w| w.document())
-        .ok_or_else(|| anyhow!("Could not get window document"))
-        .and_then(|d| {
-            d.dyn_into::<web_sys::HtmlDocument>()
-                .map_err(|_| anyhow!("Document is not an HTMLDocument"))
-        })?;
+fn set_cookie_raw(cookie_name: &str, value: &str, expires: Option<&str>) -> Result<()> {
+    let doc = get_document()?;
+    let expires = expires
+        .map(|expires| format!("; expires={expires}"))
+        .unwrap_or_default();
     let cookie_string = format!(
-        "{}={}; expires={}; sameSite=Strict; path={}/",
+        "{}={}{}; sameSite=Strict; path={}/",
         cookie_name,
-        value,
-        expiration.to_rfc2822(),
+        web_sys::js_sys::encode_uri_component(value),
+        expires,
         yew_router::utils::base_url().unwrap_or_default()
     );
     doc.set_cookie(&cookie_string)
         .map_err(|_| anyhow!("Could not set cookie"))
+}
+
+pub fn set_cookie(cookie_name: &str, value: &str, expiration: &DateTime<Utc>) -> Result<()> {
+    set_cookie_raw(cookie_name, value, Some(&expiration.to_rfc2822()))
+}
+
+pub fn set_session_cookie(cookie_name: &str, value: &str) -> Result<()> {
+    set_cookie_raw(cookie_name, value, None)
 }
 
 pub fn get_cookie(cookie_name: &str) -> Result<Option<String>> {
@@ -44,7 +49,9 @@ pub fn get_cookie(cookie_name: &str) -> Result<Option<String>> {
                 if value.is_empty() {
                     None
                 } else {
-                    Some(value.to_string())
+                    web_sys::js_sys::decode_uri_component(value)
+                        .ok()
+                        .and_then(|decoded| decoded.as_string())
                 }
             } else {
                 None

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -60,6 +60,23 @@ pub mod login {
         #[serde(rename = "refreshToken", skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,
     }
+
+    #[derive(Serialize, Deserialize, Clone)]
+    pub struct ServerTrustedHeaderResponse {
+        #[serde(rename = "userId")]
+        pub user_id: String,
+        #[serde(rename = "isAdmin")]
+        pub is_admin: bool,
+        #[serde(rename = "logoutUrl", skip_serializing_if = "Option::is_none")]
+        pub logout_url: Option<String>,
+    }
+
+    #[derive(Serialize, Deserialize, Clone)]
+    #[serde(untagged)]
+    pub enum ServerAuthResponse {
+        Token(ServerLoginResponse),
+        TrustedHeader(ServerTrustedHeaderResponse),
+    }
 }
 
 /// The messages for the 3-step OPAQUE registration process.

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -172,3 +172,22 @@ key_seed = "RanD0m STR1ng"
 ## If "ldap_host" is set to a specific IP address, this must be set to match if the built-in
 ## healthcheck command is used.
 #ldap_host = "localhost"
+
+## Options to configure trusted header authentication.
+## To set these options from environment variables, use the following format
+## (example with "enabled"): LLDAP_TRUSTED_HEADER_OPTIONS__ENABLED
+[trusted_header_options]
+## Whether to enable trusted header authentication.
+## When enabled, users can be authenticated via a trusted header (e.g. from a reverse proxy).
+## The existing username/password login will remain available as fallback.
+#enabled=false
+## Name of the header containing the username.
+#header_name="Remote-User"
+## Optional logout URL to redirect to when using trusted header authentication.
+## If not specified, users will be redirected to the regular login page.
+#logout_url="https://example.com/logout"
+## List of trusted proxy IP addresses/networks that are allowed to send trusted headers.
+## Only requests from these IPs will be authenticated via trusted headers.
+## Use CIDR notation. For a single IP, use /32 for IPv4 or /128 for IPv6.
+## Default: ["127.0.0.0/8", "::1/128"] (localhost only)
+#trusted_proxies=["127.0.0.0/8", "::1/128", "192.168.1.1/32", "10.0.0.0/8"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,6 +29,7 @@ futures = "*"
 futures-util = "*"
 hmac = "0.12"
 http = "*"
+ipnet = { version = "2.5", features = ["serde"] }
 juniper = "0.15"
 jwt = "0.16"
 ldap3_proto = "0.6.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,7 +31,7 @@ figment_file_provider_adapter = "0.1"
 futures = "0"
 futures-util = "0"
 hmac = "0.12"
-http = "*"
+http = "1"
 ipnet = { version = "2.5", features = ["serde"] }
 juniper = { workspace = true }
 jwt = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,6 +31,8 @@ figment_file_provider_adapter = "0.1"
 futures = "0"
 futures-util = "0"
 hmac = "0.12"
+http = "*"
+ipnet = { version = "2.5", features = ["serde"] }
 juniper = { workspace = true }
 jwt = { workspace = true }
 ldap3_proto = { workspace = true }

--- a/server/src/auth_service.rs
+++ b/server/src/auth_service.rs
@@ -3,7 +3,7 @@ use crate::{
     tcp_server::{AppState, TcpError, TcpResult, error_to_http_response},
 };
 use actix_web::{
-    HttpRequest, HttpResponse,
+    FromRequest, HttpRequest, HttpResponse,
     cookie::{Cookie, SameSite},
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
     error::{ErrorBadRequest, ErrorUnauthorized},
@@ -534,11 +534,9 @@ where
 {
     use actix_web::FromRequest;
     let inner_payload = &mut payload.into_inner();
-    let validation_result = BearerAuth::from_request(&request, inner_payload)
+    let validation_result = get_validation_results(&data, &request, inner_payload)
         .await
-        .ok()
-        .and_then(|bearer| check_if_token_is_valid(&data, bearer.token()).ok())
-        .ok_or_else(|| {
+        .map_err(|_| {
             TcpError::UnauthorizedError("Not authorized to change the user's password".to_string())
         })?;
     let registration_start_request =
@@ -660,6 +658,25 @@ where
         };
 
         Box::pin(self.service.call(req))
+    }
+}
+
+#[instrument(skip_all, level = "debug", err, ret)]
+pub(crate) async fn get_validation_results<Backend: BackendHandler>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+    payload: &mut actix_http::Payload,
+) -> Result<ValidationResults, actix_web::Error> {
+    if data.trusted_header_options.enabled
+        && request
+            .headers()
+            .contains_key(&data.trusted_header_options.header_name)
+    {
+        check_if_trusted_header_is_valid(data, request).await
+    } else {
+        BearerAuth::from_request(request, payload)
+            .await
+            .map(|bearer| check_if_token_is_valid(data.get_ref(), bearer.token()))?
     }
 }
 

--- a/server/src/auth_service.rs
+++ b/server/src/auth_service.rs
@@ -105,8 +105,25 @@ async fn get_refresh<Backend>(
 where
     Backend: TcpBackendHandler + BackendHandler + 'static,
 {
+    if data.trusted_header_options.enabled
+        && request
+            .headers()
+            .contains_key(&data.trusted_header_options.header_name)
+    {
+        return get_trusted_header_refresh_response(&data, &request).await;
+    }
+    try_refresh_token(&data, &request).await
+}
+
+async fn try_refresh_token<Backend>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + 'static,
+{
     let jwt_key = &data.jwt_key;
-    let (refresh_token_hash, user) = get_refresh_token(request)?;
+    let (refresh_token_hash, user) = get_refresh_token(request.clone())?;
     let found = data
         .get_tcp_handler()
         .check_token(refresh_token_hash, &user)
@@ -131,10 +148,84 @@ where
                 .same_site(SameSite::Strict)
                 .finish(),
         )
-        .json(&login::ServerLoginResponse {
-            token: token.as_str().to_owned(),
-            refresh_token: None,
-        }))
+        .json(login::ServerAuthResponse::Token(
+            login::ServerLoginResponse {
+                token: token.as_str().to_owned(),
+                refresh_token: None,
+            },
+        )))
+}
+
+async fn validate_trusted_header<Backend>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+) -> TcpResult<(UserId, HashSet<GroupDetails>)>
+where
+    Backend: BackendHandler,
+{
+    // Validate client IP is in trusted CIDRs
+    let client_ip = request
+        .peer_addr()
+        .map(|peer_addr| peer_addr.ip())
+        .ok_or_else(|| TcpError::UnauthorizedError("Could not determine client IP".to_string()))?;
+
+    if !data
+        .trusted_header_options
+        .trusted_proxies
+        .iter()
+        .any(|cidr| cidr.contains(&client_ip))
+    {
+        return Err(TcpError::UnauthorizedError(format!(
+            "Client IP {} not in trusted proxies",
+            client_ip
+        )));
+    }
+
+    // Get the username from the trusted header
+    let header_name = &data.trusted_header_options.header_name;
+    let username = request
+        .headers()
+        .get(header_name)
+        .and_then(|h| h.to_str().ok())
+        .ok_or_else(|| {
+            TcpError::UnauthorizedError(format!("Missing trusted header: {}", header_name))
+        })?;
+
+    // Validate the username is not empty
+    if username.trim().is_empty() {
+        return Err(TcpError::UnauthorizedError(
+            "Empty username in trusted header".to_string(),
+        ));
+    }
+
+    let user_id = UserId::new(username);
+    let groups = data
+        .get_readonly_handler()
+        .get_user_groups(&user_id)
+        .await?;
+
+    Ok((user_id, groups))
+}
+
+async fn get_trusted_header_refresh_response<Backend>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+) -> TcpResult<HttpResponse>
+where
+    Backend: BackendHandler,
+{
+    let (user_id, groups) = validate_trusted_header(data, request).await?;
+    let is_admin = groups
+        .iter()
+        .any(|g| g.display_name == "lldap_admin".into());
+
+    Ok(gen_clear_session_cookies_response(&data.server_url).json(
+        login::ServerAuthResponse::TrustedHeader(login::ServerTrustedHeaderResponse {
+            user_id: user_id.to_string(),
+            is_admin,
+            logout_url: data.trusted_header_options.logout_url.clone(),
+        }),
+    ))
 }
 
 async fn get_refresh_handler<Backend>(
@@ -296,28 +387,7 @@ where
     for jwt_hash in new_blacklisted_jwt_hashes {
         jwt_blacklist.insert(jwt_hash);
     }
-    let mut path = data.server_url.path().to_string();
-    if !path.ends_with('/') {
-        path.push('/');
-    };
-    Ok(HttpResponse::Ok()
-        .cookie(
-            Cookie::build("token", "")
-                .max_age(0.days())
-                .path(&path)
-                .http_only(true)
-                .same_site(SameSite::Strict)
-                .finish(),
-        )
-        .cookie(
-            Cookie::build("refresh_token", "")
-                .max_age(0.days())
-                .path(format!("{path}auth"))
-                .http_only(true)
-                .same_site(SameSite::Strict)
-                .finish(),
-        )
-        .finish())
+    Ok(gen_clear_session_cookies_response(&data.server_url).finish())
 }
 
 async fn get_logout_handler<Backend>(
@@ -621,6 +691,55 @@ pub(crate) fn check_if_token_is_valid<Backend: BackendHandler>(
             .iter()
             .map(|s| GroupName::from(s.as_str())),
     ))
+}
+
+#[instrument(skip_all, level = "debug", err, ret)]
+pub(crate) async fn check_if_trusted_header_is_valid<Backend: BackendHandler>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+) -> Result<ValidationResults, actix_web::Error> {
+    if !data.trusted_header_options.enabled {
+        return Err(ErrorUnauthorized(
+            "Trusted header authentication is disabled",
+        ));
+    }
+
+    let (user_id, groups) = validate_trusted_header(data, request)
+        .await
+        .map_err(|e| ErrorUnauthorized(e.to_string()))?;
+
+    Ok(data.backend_handler.get_permissions_from_groups(
+        user_id,
+        groups
+            .iter()
+            .map(|g| GroupName::from(g.display_name.as_str())),
+    ))
+}
+
+fn gen_clear_session_cookies_response(server_url: &url::Url) -> actix_web::HttpResponseBuilder {
+    let mut path = server_url.path().to_string();
+    if !path.ends_with('/') {
+        path.push('/');
+    };
+    let mut builder = HttpResponse::Ok();
+    builder
+        .cookie(
+            Cookie::build("token", "")
+                .max_age(0.days())
+                .path(&path)
+                .http_only(true)
+                .same_site(SameSite::Strict)
+                .finish(),
+        )
+        .cookie(
+            Cookie::build("refresh_token", "")
+                .max_age(0.days())
+                .path(format!("{path}auth"))
+                .http_only(true)
+                .same_site(SameSite::Strict)
+                .finish(),
+        );
+    builder
 }
 
 pub fn configure_server<Backend>(cfg: &mut web::ServiceConfig, enable_password_reset: bool)

--- a/server/src/auth_service.rs
+++ b/server/src/auth_service.rs
@@ -3,10 +3,11 @@ use crate::{
     tcp_server::{AppState, TcpError, TcpResult, error_to_http_response},
 };
 use actix_web::{
-    HttpRequest, HttpResponse,
+    FromRequest, HttpRequest, HttpResponse,
     cookie::{Cookie, SameSite},
     dev::{Service, ServiceRequest, ServiceResponse, Transform},
     error::{ErrorBadRequest, ErrorUnauthorized},
+    http::header::HeaderValue,
     web,
 };
 use actix_web_httpauth::extractors::bearer::BearerAuth;
@@ -30,6 +31,7 @@ use sha2::Sha512;
 use std::{
     collections::HashSet,
     hash::Hash,
+    net::IpAddr,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -105,8 +107,25 @@ async fn get_refresh<Backend>(
 where
     Backend: TcpBackendHandler + BackendHandler + 'static,
 {
+    if data.trusted_header_options.enabled
+        && let Some(header_value) = request
+            .headers()
+            .get(&data.trusted_header_options.header_name)
+    {
+        return get_trusted_header_refresh_response(&data, &request, header_value).await;
+    }
+    try_refresh_token(&data, &request).await
+}
+
+async fn try_refresh_token<Backend>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + 'static,
+{
     let jwt_key = &data.jwt_key;
-    let (refresh_token_hash, user) = get_refresh_token(request)?;
+    let (refresh_token_hash, user) = get_refresh_token(request.clone())?;
     let found = data
         .get_tcp_handler()
         .check_token(refresh_token_hash, &user)
@@ -131,10 +150,85 @@ where
                 .same_site(SameSite::Strict)
                 .finish(),
         )
-        .json(&login::ServerLoginResponse {
-            token: token.as_str().to_owned(),
-            refresh_token: None,
-        }))
+        .json(login::ServerAuthResponse::Token(
+            login::ServerLoginResponse {
+                token: token.as_str().to_owned(),
+                refresh_token: None,
+            },
+        )))
+}
+
+async fn validate_trusted_header<Backend>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+    header_value: &HeaderValue,
+) -> TcpResult<(UserId, HashSet<GroupDetails>)>
+where
+    Backend: BackendHandler,
+{
+    // Validate client IP is in trusted CIDRs
+    let client_ip = request
+        .peer_addr()
+        .map(|peer_addr| peer_addr.ip())
+        .ok_or_else(|| TcpError::UnauthorizedError("Could not determine client IP".to_string()))?;
+
+    validate_trusted_proxy(client_ip, &data.trusted_header_options.trusted_proxies)?;
+
+    // Get the username from the trusted header value selected by the caller.
+    let header_name = &data.trusted_header_options.header_name;
+    let username = header_value.to_str().map_err(|_| {
+        TcpError::UnauthorizedError(format!(
+            "Trusted header `{}` is not valid UTF-8",
+            header_name
+        ))
+    })?;
+
+    // Validate the username is not empty
+    if username.trim().is_empty() {
+        return Err(TcpError::UnauthorizedError(
+            "Empty username in trusted header".to_string(),
+        ));
+    }
+
+    let user_id = UserId::new(username);
+    let groups = data
+        .get_readonly_handler()
+        .get_user_groups(&user_id)
+        .await?;
+
+    Ok((user_id, groups))
+}
+
+fn validate_trusted_proxy(client_ip: IpAddr, trusted_proxies: &[ipnet::IpNet]) -> TcpResult<()> {
+    if trusted_proxies.iter().any(|cidr| cidr.contains(&client_ip)) {
+        return Ok(());
+    }
+
+    Err(TcpError::UnauthorizedError(format!(
+        "Request arrived from untrusted client IP {client_ip}. When trusted header authentication is enabled, LLDAP must only be reachable through a trusted proxy. Configure the proxy's address or network in `trusted_proxies` and prevent direct client access to LLDAP"
+    )))
+}
+
+async fn get_trusted_header_refresh_response<Backend>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+    header_value: &HeaderValue,
+) -> TcpResult<HttpResponse>
+where
+    Backend: BackendHandler,
+{
+    let (user_id, groups) = validate_trusted_header(data, request, header_value).await?;
+    let is_admin = groups
+        .iter()
+        .any(|g| g.display_name == "lldap_admin".into());
+
+    Ok(gen_clear_session_cookies_response(&data.server_url).json(
+        login::ServerAuthResponse::TrustedHeader(login::ServerTrustedHeaderResponse {
+            user_id: user_id.to_string(),
+            is_admin,
+            logout_url: data.trusted_header_options.logout_url.clone(),
+        }),
+    ))
 }
 
 async fn get_refresh_handler<Backend>(
@@ -296,28 +390,7 @@ where
     for jwt_hash in new_blacklisted_jwt_hashes {
         jwt_blacklist.insert(jwt_hash);
     }
-    let mut path = data.server_url.path().to_string();
-    if !path.ends_with('/') {
-        path.push('/');
-    };
-    Ok(HttpResponse::Ok()
-        .cookie(
-            Cookie::build("token", "")
-                .max_age(0.days())
-                .path(&path)
-                .http_only(true)
-                .same_site(SameSite::Strict)
-                .finish(),
-        )
-        .cookie(
-            Cookie::build("refresh_token", "")
-                .max_age(0.days())
-                .path(format!("{path}auth"))
-                .http_only(true)
-                .same_site(SameSite::Strict)
-                .finish(),
-        )
-        .finish())
+    Ok(gen_clear_session_cookies_response(&data.server_url).finish())
 }
 
 async fn get_logout_handler<Backend>(
@@ -464,11 +537,9 @@ where
 {
     use actix_web::FromRequest;
     let inner_payload = &mut payload.into_inner();
-    let validation_result = BearerAuth::from_request(&request, inner_payload)
+    let validation_result = get_validation_results(&data, &request, inner_payload)
         .await
-        .ok()
-        .and_then(|bearer| check_if_token_is_valid(&data, bearer.token()).ok())
-        .ok_or_else(|| {
+        .map_err(|_| {
             TcpError::UnauthorizedError("Not authorized to change the user's password".to_string())
         })?;
     let registration_start_request =
@@ -594,6 +665,24 @@ where
 }
 
 #[instrument(skip_all, level = "debug", err, ret)]
+pub(crate) async fn get_validation_results<Backend: BackendHandler>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+    payload: &mut actix_http::Payload,
+) -> Result<ValidationResults, actix_web::Error> {
+    if data.trusted_header_options.enabled
+        && let Some(header_value) = request
+            .headers()
+            .get(&data.trusted_header_options.header_name)
+    {
+        return check_if_trusted_header_is_valid(data, request, header_value).await;
+    }
+    BearerAuth::from_request(request, payload)
+        .await
+        .map(|bearer| check_if_token_is_valid(data.get_ref(), bearer.token()))?
+}
+
+#[instrument(skip_all, level = "debug", err, ret)]
 pub(crate) fn check_if_token_is_valid<Backend: BackendHandler>(
     state: &AppState<Backend>,
     token_str: &str,
@@ -621,6 +710,50 @@ pub(crate) fn check_if_token_is_valid<Backend: BackendHandler>(
             .iter()
             .map(|s| GroupName::from(s.as_str())),
     ))
+}
+
+#[instrument(skip_all, level = "debug", err, ret)]
+pub(crate) async fn check_if_trusted_header_is_valid<Backend: BackendHandler>(
+    data: &web::Data<AppState<Backend>>,
+    request: &HttpRequest,
+    header_value: &HeaderValue,
+) -> Result<ValidationResults, actix_web::Error> {
+    let (user_id, groups) = validate_trusted_header(data, request, header_value)
+        .await
+        .map_err(actix_web::Error::from)?;
+
+    Ok(data.backend_handler.get_permissions_from_groups(
+        user_id,
+        groups
+            .iter()
+            .map(|g| GroupName::from(g.display_name.as_str())),
+    ))
+}
+
+fn gen_clear_session_cookies_response(server_url: &url::Url) -> actix_web::HttpResponseBuilder {
+    let mut path = server_url.path().to_string();
+    if !path.ends_with('/') {
+        path.push('/');
+    };
+    let mut builder = HttpResponse::Ok();
+    builder
+        .cookie(
+            Cookie::build("token", "")
+                .max_age(0.days())
+                .path(&path)
+                .http_only(true)
+                .same_site(SameSite::Strict)
+                .finish(),
+        )
+        .cookie(
+            Cookie::build("refresh_token", "")
+                .max_age(0.days())
+                .path(format!("{path}auth"))
+                .http_only(true)
+                .same_site(SameSite::Strict)
+                .finish(),
+        );
+    builder
 }
 
 pub fn configure_server<Backend>(cfg: &mut web::ServiceConfig, enable_password_reset: bool)
@@ -661,6 +794,116 @@ where
     } else {
         cfg.service(
             web::resource("/reset/step1/{user_id}").route(web::post().to(HttpResponse::NotFound)),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::configuration::{MailOptions, TrustedHeaderOptions};
+    use actix_web::{http::StatusCode, test as actix_test};
+    use lldap_access_control::AccessControlledBackendHandler;
+    use lldap_auth::opaque::server::generate_random_private_key;
+    use lldap_domain::requests::CreateUserRequest;
+    use lldap_domain_handlers::handler::UserBackendHandler;
+    use lldap_sql_backend_handler::{SqlBackendHandler, sql_tables::init_table};
+    use sea_orm::{ConnectOptions, Database};
+    use std::{path::PathBuf, sync::RwLock};
+
+    const HEADER_USER: &str = "header-user";
+
+    struct AuthTestFixture {
+        data: web::Data<AppState<SqlBackendHandler>>,
+    }
+
+    impl AuthTestFixture {
+        async fn new() -> Self {
+            let mut connect_options = ConnectOptions::new("sqlite::memory:");
+            connect_options.max_connections(1);
+            let pool = Database::connect(connect_options).await.unwrap();
+            init_table(&pool).await.unwrap();
+
+            let backend = SqlBackendHandler::new(generate_random_private_key(), pool);
+            backend
+                .create_user(CreateUserRequest {
+                    user_id: UserId::new(HEADER_USER),
+                    email: format!("{HEADER_USER}@example.com").into(),
+                    display_name: None,
+                    attributes: Vec::new(),
+                })
+                .await
+                .unwrap();
+
+            let trusted_header_options = TrustedHeaderOptions {
+                enabled: true,
+                header_name: "Remote-User".to_owned(),
+                logout_url: None,
+                trusted_proxies: vec!["127.0.0.0/8".parse().unwrap()],
+            };
+            let data = web::Data::new(AppState {
+                backend_handler: AccessControlledBackendHandler::new(backend),
+                jwt_key: hmac::Mac::new_from_slice(b"test-jwt-secret").unwrap(),
+                jwt_blacklist: RwLock::new(HashSet::new()),
+                server_url: "http://localhost/".parse().unwrap(),
+                assets_path: PathBuf::new(),
+                mail_options: MailOptions::default(),
+                trusted_header_options,
+            });
+            Self { data }
+        }
+    }
+
+    fn trusted_header_request() -> (HttpRequest, actix_http::Payload) {
+        actix_test::TestRequest::default()
+            .peer_addr("127.0.0.1:12345".parse().unwrap())
+            .insert_header(("Remote-User", HEADER_USER))
+            .to_http_parts()
+    }
+
+    #[test]
+    fn untrusted_proxy_error_explains_how_to_fix_the_configuration() {
+        let client_ip = "192.0.2.10".parse().unwrap();
+        let trusted_proxies = ["127.0.0.0/8".parse().unwrap()];
+
+        let error = validate_trusted_proxy(client_ip, &trusted_proxies).unwrap_err();
+        let message = error.to_string();
+
+        assert!(matches!(error, TcpError::UnauthorizedError(_)));
+        assert!(message.contains("untrusted client IP 192.0.2.10"));
+        assert!(message.contains("trusted_proxies"));
+        assert!(message.contains("prevent direct client access"));
+    }
+
+    #[test]
+    fn trusted_proxy_is_accepted() {
+        let client_ip = "192.0.2.10".parse().unwrap();
+        let trusted_proxies = ["192.0.2.0/24".parse().unwrap()];
+
+        assert!(validate_trusted_proxy(client_ip, &trusted_proxies).is_ok());
+    }
+
+    #[actix_web::test]
+    async fn trusted_header_backend_failure_remains_500() {
+        let fixture = AuthTestFixture::new().await;
+        fixture
+            .data
+            .backend_handler
+            .unsafe_get_handler()
+            .pool()
+            .clone()
+            .close()
+            .await
+            .unwrap();
+        let (request, mut payload) = trusted_header_request();
+
+        let error = get_validation_results(&fixture.data, &request, &mut payload)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.as_response_error().status_code(),
+            StatusCode::INTERNAL_SERVER_ERROR
         );
     }
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -177,6 +177,9 @@ pub struct RunOpts {
 
     #[clap(flatten)]
     pub healthcheck_opts: HealthcheckOpts,
+
+    #[clap(flatten)]
+    pub trusted_header_opts: TrustedHeaderOpts,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -210,6 +213,26 @@ pub struct LdapsOpts {
     /// Ldaps certificate key file. Default: key.pem
     #[clap(long, env = "LLDAP_LDAPS_OPTIONS__KEY_FILE")]
     pub ldaps_key_file: Option<String>,
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(next_help_heading = Some("Trusted Header Authentication"))]
+pub struct TrustedHeaderOpts {
+    /// Enable trusted header authentication. Default: false.
+    #[clap(long, env = "LLDAP_TRUSTED_HEADER_OPTIONS__ENABLED")]
+    pub trusted_header_enabled: Option<bool>,
+
+    /// Header name containing the username. Default: Remote-User
+    #[clap(long, env = "LLDAP_TRUSTED_HEADER_OPTIONS__HEADER_NAME")]
+    pub trusted_header_name: Option<String>,
+
+    /// Logout URL to redirect to when using trusted headers
+    #[clap(long, env = "LLDAP_TRUSTED_HEADER_OPTIONS__LOGOUT_URL")]
+    pub trusted_header_logout_url: Option<String>,
+
+    /// Trusted proxy CIDR ranges (comma-separated). Use /32 for a single IPv4 and /128 for a single IPv6.
+    #[clap(long, env = "LLDAP_TRUSTED_HEADER_OPTIONS__TRUSTED_PROXIES")]
+    pub trusted_header_trusted_proxies: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, clap::ValueEnum)]

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
         GeneralConfigOpts, HealthcheckOpts, LdapsOpts, RunOpts, SmtpEncryption, SmtpOpts,
-        TestEmailOpts, TrueFalseAlways,
+        TestEmailOpts, TrueFalseAlways, TrustedHeaderOpts,
     },
     database_string::DatabaseUrl,
 };
@@ -11,6 +11,7 @@ use figment::{
     providers::{Env, Format, Serialized, Toml},
 };
 use figment_file_provider_adapter::FileAdapter;
+use ipnet::IpNet;
 use lldap_auth::opaque::{
     KeyPair,
     server::{ServerSetup, generate_random_private_key},
@@ -98,6 +99,25 @@ impl std::default::Default for HealthcheckOptions {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, derive_builder::Builder)]
+#[builder(pattern = "owned")]
+pub struct TrustedHeaderOptions {
+    #[builder(default = "false")]
+    pub enabled: bool,
+    #[builder(default = r#"String::from("Remote-User")"#)]
+    pub header_name: String,
+    #[builder(default = "None")]
+    pub logout_url: Option<String>,
+    #[builder(default = r#"vec!["127.0.0.0/8".parse().unwrap(), "::1/128".parse().unwrap()]"#)]
+    pub trusted_proxies: Vec<IpNet>,
+}
+
+impl std::default::Default for TrustedHeaderOptions {
+    fn default() -> Self {
+        TrustedHeaderOptionsBuilder::default().build().unwrap()
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize, derive_more::Debug)]
 #[debug(r#""{_0}""#)]
 pub struct HttpUrl(pub Url);
@@ -147,6 +167,8 @@ pub struct Configuration {
     pub smtp_options: MailOptions,
     #[builder(default)]
     pub ldaps_options: LdapsOptions,
+    #[builder(default)]
+    pub trusted_header_options: TrustedHeaderOptions,
     #[builder(default = r#"HttpUrl(Url::parse("http://localhost").unwrap())"#)]
     pub http_url: HttpUrl,
     #[debug(skip)]
@@ -465,6 +487,7 @@ impl ConfigOverrider for RunOpts {
 
         self.smtp_opts.override_config(config);
         self.ldaps_opts.override_config(config);
+        self.trusted_header_opts.override_config(config);
     }
 }
 
@@ -490,6 +513,37 @@ impl ConfigOverrider for LdapsOpts {
         self.ldaps_key_file
             .as_ref()
             .inspect(|path| config.ldaps_options.key_file.clone_from(path));
+    }
+}
+
+impl ConfigOverrider for TrustedHeaderOpts {
+    fn override_config(&self, config: &mut Configuration) {
+        self.trusted_header_enabled
+            .inspect(|&enabled| config.trusted_header_options.enabled = enabled);
+
+        self.trusted_header_name.as_ref().inspect(|&header_name| {
+            config
+                .trusted_header_options
+                .header_name
+                .clone_from(header_name)
+        });
+
+        self.trusted_header_logout_url
+            .as_ref()
+            .inspect(|&logout_url| {
+                config.trusted_header_options.logout_url = Some(logout_url.clone())
+            });
+
+        self.trusted_header_trusted_proxies
+            .as_ref()
+            .inspect(|trusted_proxies| {
+                config.trusted_header_options.trusted_proxies = trusted_proxies
+                    .split(',')
+                    .map(str::trim)
+                    .map(str::parse)
+                    .collect::<std::result::Result<_, _>>()
+                    .expect("Invalid trusted proxy CIDR");
+            });
     }
 }
 
@@ -872,6 +926,50 @@ mod tests {
                 error_message.contains("but it used to come from default key file",),
                 "{error_message}"
             );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn check_trusted_proxies_parsing_env_valid() {
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env(
+                "LLDAP_TRUSTED_HEADER_OPTIONS__TRUSTED_PROXIES",
+                "10.0.0.0/8, 192.168.1.1/32, ::1/128",
+            );
+
+            let opts = default_run_opts();
+            let mut config = Configuration::default();
+            opts.override_config(&mut config);
+
+            assert_eq!(
+                config.trusted_header_options.trusted_proxies,
+                vec![
+                    "10.0.0.0/8".parse().unwrap(),
+                    "192.168.1.1/32".parse().unwrap(),
+                    "::1/128".parse().unwrap()
+                ]
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn check_trusted_proxies_parsing_env_invalid() {
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env(
+                "LLDAP_TRUSTED_HEADER_OPTIONS__TRUSTED_PROXIES",
+                "10.0.0.0/8,not-a-cidr",
+            );
+
+            let panic = std::panic::catch_unwind(|| {
+                let opts = default_run_opts();
+                let mut config = Configuration::default();
+                opts.override_config(&mut config);
+            });
+            assert!(panic.is_err());
             Ok(())
         });
     }

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
         GeneralConfigOpts, HealthcheckOpts, LdapsOpts, RunOpts, SmtpEncryption, SmtpOpts,
-        TestEmailOpts, TrueFalseAlways,
+        TestEmailOpts, TrueFalseAlways, TrustedHeaderOpts,
     },
     database_string::DatabaseUrl,
 };
@@ -11,6 +11,7 @@ use figment::{
     providers::{Env, Format, Serialized, Toml},
 };
 use figment_file_provider_adapter::FileAdapter;
+use ipnet::IpNet;
 use lldap_auth::opaque::{
     KeyPair,
     server::{ServerSetup, generate_random_private_key},
@@ -98,6 +99,25 @@ impl std::default::Default for HealthcheckOptions {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, derive_builder::Builder)]
+#[builder(pattern = "owned")]
+pub struct TrustedHeaderOptions {
+    #[builder(default = "false")]
+    pub enabled: bool,
+    #[builder(default = r#"String::from("Remote-User")"#)]
+    pub header_name: String,
+    #[builder(default = "None")]
+    pub logout_url: Option<String>,
+    #[builder(default = r#"vec!["127.0.0.0/8".parse().unwrap(), "::1/128".parse().unwrap()]"#)]
+    pub trusted_proxies: Vec<IpNet>,
+}
+
+impl std::default::Default for TrustedHeaderOptions {
+    fn default() -> Self {
+        TrustedHeaderOptionsBuilder::default().build().unwrap()
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize, derive_more::Debug)]
 #[debug(r#""{_0}""#)]
 pub struct HttpUrl(pub Url);
@@ -147,6 +167,8 @@ pub struct Configuration {
     pub smtp_options: MailOptions,
     #[builder(default)]
     pub ldaps_options: LdapsOptions,
+    #[builder(default)]
+    pub trusted_header_options: TrustedHeaderOptions,
     #[builder(default = r#"HttpUrl(Url::parse("http://localhost").unwrap())"#)]
     pub http_url: HttpUrl,
     #[debug(skip)]
@@ -465,6 +487,7 @@ impl ConfigOverrider for RunOpts {
 
         self.smtp_opts.override_config(config);
         self.ldaps_opts.override_config(config);
+        self.trusted_header_opts.override_config(config);
     }
 }
 
@@ -490,6 +513,37 @@ impl ConfigOverrider for LdapsOpts {
         self.ldaps_key_file
             .as_ref()
             .inspect(|path| config.ldaps_options.key_file.clone_from(path));
+    }
+}
+
+impl ConfigOverrider for TrustedHeaderOpts {
+    fn override_config(&self, config: &mut Configuration) {
+        self.trusted_header_enabled
+            .inspect(|&enabled| config.trusted_header_options.enabled = enabled);
+
+        self.trusted_header_name.as_ref().inspect(|header_name| {
+            config
+                .trusted_header_options
+                .header_name
+                .clone_from(header_name)
+        });
+
+        self.trusted_header_logout_url
+            .as_ref()
+            .inspect(|logout_url| {
+                config.trusted_header_options.logout_url = Some(logout_url.to_string())
+            });
+
+        self.trusted_header_trusted_proxies
+            .as_ref()
+            .inspect(|trusted_proxies| {
+                config.trusted_header_options.trusted_proxies = trusted_proxies
+                    .split(',')
+                    .map(str::trim)
+                    .map(str::parse)
+                    .collect::<std::result::Result<_, _>>()
+                    .expect("Invalid trusted proxy CIDR");
+            });
     }
 }
 
@@ -871,6 +925,32 @@ mod tests {
             assert!(
                 error_message.contains("but it used to come from default key file",),
                 "{error_message}"
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn trusted_proxies_override_parses_ipv4_and_ipv6() {
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env(
+                "LLDAP_TRUSTED_HEADER_OPTIONS__TRUSTED_PROXIES",
+                "10.0.0.0/8,  192.168.1.42/32,\t2001:db8::/32, ::1/128",
+            );
+
+            let opts = default_run_opts();
+            let mut config = Configuration::default();
+            opts.override_config(&mut config);
+
+            assert_eq!(
+                config.trusted_header_options.trusted_proxies,
+                vec![
+                    "10.0.0.0/8".parse::<IpNet>().unwrap(),
+                    "192.168.1.42/32".parse::<IpNet>().unwrap(),
+                    "2001:db8::/32".parse::<IpNet>().unwrap(),
+                    "::1/128".parse::<IpNet>().unwrap(),
+                ]
             );
             Ok(())
         });

--- a/server/src/graphql_server.rs
+++ b/server/src/graphql_server.rs
@@ -1,11 +1,7 @@
-use crate::{
-    auth_service::{check_if_token_is_valid, check_if_trusted_header_is_valid},
-    tcp_server::AppState,
-};
+use crate::{auth_service::get_validation_results, tcp_server::AppState};
 use actix_web::FromRequest;
 use actix_web::HttpMessage;
 use actix_web::{Error, HttpRequest, HttpResponse, error::JsonPayloadError, web};
-use actix_web_httpauth::extractors::bearer::BearerAuth;
 use juniper::{
     ScalarValue,
     http::{
@@ -130,28 +126,12 @@ async fn graphql_route<Handler: BackendHandler + Clone>(
 ) -> Result<HttpResponse, Error> {
     let mut inner_payload = payload.into_inner();
 
-    let validation_result = if data.trusted_header_options.enabled
-        && req
-            .headers()
-            .contains_key(&data.trusted_header_options.header_name)
-    {
-        // Use trusted header authentication
-        check_if_trusted_header_is_valid(&data, &req)
-            .await
-            .map_err(|e| {
-                warn!("Trusted header authentication failed: {}", e);
-                e
-            })?
-    } else {
-        // Use JWT authentication
-        BearerAuth::from_request(&req, &mut inner_payload)
-            .await
-            .map(|bearer| check_if_token_is_valid(data.get_ref(), bearer.token()))?
-            .map_err(|e| {
-                warn!("JWT authentication failed: {}", e);
-                e
-            })?
-    };
+    let validation_result = get_validation_results(&data, &req, &mut inner_payload)
+        .await
+        .map_err(|e| {
+            warn!("Authentication failed: {}", e);
+            e
+        })?;
 
     let context = Context::<Handler> {
         handler: data.backend_handler.clone(),

--- a/server/src/graphql_server.rs
+++ b/server/src/graphql_server.rs
@@ -1,4 +1,7 @@
-use crate::{auth_service::check_if_token_is_valid, tcp_server::AppState};
+use crate::{
+    auth_service::{check_if_token_is_valid, check_if_trusted_header_is_valid},
+    tcp_server::AppState,
+};
 use actix_web::FromRequest;
 use actix_web::HttpMessage;
 use actix_web::{Error, HttpRequest, HttpResponse, error::JsonPayloadError, web};
@@ -13,6 +16,7 @@ use juniper::{
 use lldap_domain_handlers::handler::BackendHandler;
 use lldap_graphql_server::api::Context;
 use lldap_graphql_server::api::schema;
+use tracing::warn;
 
 async fn graphiql_route() -> Result<HttpResponse, Error> {
     let html = graphiql_source("/api/graphql", None);
@@ -125,8 +129,30 @@ async fn graphql_route<Handler: BackendHandler + Clone>(
     data: web::Data<AppState<Handler>>,
 ) -> Result<HttpResponse, Error> {
     let mut inner_payload = payload.into_inner();
-    let bearer = BearerAuth::from_request(&req, &mut inner_payload).await?;
-    let validation_result = check_if_token_is_valid(&data, bearer.token())?;
+
+    let validation_result = if data.trusted_header_options.enabled
+        && req
+            .headers()
+            .contains_key(&data.trusted_header_options.header_name)
+    {
+        // Use trusted header authentication
+        check_if_trusted_header_is_valid(&data, &req)
+            .await
+            .map_err(|e| {
+                warn!("Trusted header authentication failed: {}", e);
+                e
+            })?
+    } else {
+        // Use JWT authentication
+        BearerAuth::from_request(&req, &mut inner_payload)
+            .await
+            .map(|bearer| check_if_token_is_valid(data.get_ref(), bearer.token()))?
+            .map_err(|e| {
+                warn!("JWT authentication failed: {}", e);
+                e
+            })?
+    };
+
     let context = Context::<Handler> {
         handler: data.backend_handler.clone(),
         validation_result,

--- a/server/src/graphql_server.rs
+++ b/server/src/graphql_server.rs
@@ -1,8 +1,7 @@
-use crate::{auth_service::check_if_token_is_valid, tcp_server::AppState};
+use crate::{auth_service::get_validation_results, tcp_server::AppState};
 use actix_web::FromRequest;
 use actix_web::HttpMessage;
 use actix_web::{Error, HttpRequest, HttpResponse, error::JsonPayloadError, web};
-use actix_web_httpauth::extractors::bearer::BearerAuth;
 use juniper::{
     ScalarValue,
     http::{
@@ -13,6 +12,7 @@ use juniper::{
 use lldap_domain_handlers::handler::BackendHandler;
 use lldap_graphql_server::api::Context;
 use lldap_graphql_server::api::schema;
+use tracing::warn;
 
 async fn graphiql_route() -> Result<HttpResponse, Error> {
     let html = graphiql_source("/api/graphql", None);
@@ -125,8 +125,12 @@ async fn graphql_route<Handler: BackendHandler + Clone>(
     data: web::Data<AppState<Handler>>,
 ) -> Result<HttpResponse, Error> {
     let mut inner_payload = payload.into_inner();
-    let bearer = BearerAuth::from_request(&req, &mut inner_payload).await?;
-    let validation_result = check_if_token_is_valid(&data, bearer.token())?;
+    let validation_result = get_validation_results(&data, &req, &mut inner_payload)
+        .await
+        .map_err(|e| {
+            warn!("Authentication failed: {}", e);
+            e
+        })?;
     let context = Context::<Handler> {
         handler: data.backend_handler.clone(),
         validation_result,

--- a/server/src/tcp_server.rs
+++ b/server/src/tcp_server.rs
@@ -1,6 +1,6 @@
 use crate::{
     auth_service,
-    configuration::{Configuration, MailOptions},
+    configuration::{Configuration, MailOptions, TrustedHeaderOptions},
     logging::CustomRootSpanBuilder,
     tcp_backend_handler::*,
 };
@@ -8,7 +8,9 @@ use actix_files::Files;
 use actix_http::{HttpServiceBuilder, header};
 use actix_server::ServerBuilder;
 use actix_service::map_config;
-use actix_web::{App, HttpResponse, Responder, dev::AppConfig, guard, web};
+use actix_web::{
+    App, HttpResponse, Responder, ResponseError, dev::AppConfig, guard, http::StatusCode, web,
+};
 use anyhow::{Context, Result};
 use hmac::Hmac;
 use lldap_access_control::{AccessControlledBackendHandler, ReadonlyBackendHandler};
@@ -52,26 +54,34 @@ pub enum TcpError {
 
 pub type TcpResult<T> = std::result::Result<T, TcpError>;
 
-pub(crate) fn error_to_http_response(error: TcpError) -> HttpResponse {
-    match error {
-        TcpError::DomainError(ref de) => match de {
-            DomainError::AuthenticationError(_) | DomainError::AuthenticationProtocolError(_) => {
-                HttpResponse::Unauthorized()
-            }
-            DomainError::DatabaseError(_)
-            | DomainError::DatabaseTransactionError(_)
-            | DomainError::InternalError(_)
-            | DomainError::UnknownCryptoError(_) => HttpResponse::InternalServerError(),
-            DomainError::Base64DecodeError(_)
-            | DomainError::BinarySerializationError(_)
-            | DomainError::EntityNotFound(_) => HttpResponse::BadRequest(),
-        },
-        TcpError::BadRequest(_) => HttpResponse::BadRequest(),
-        TcpError::NotFoundError(_) => HttpResponse::NotFound(),
-        TcpError::InternalServerError(_) => HttpResponse::InternalServerError(),
-        TcpError::UnauthorizedError(_) => HttpResponse::Unauthorized(),
+impl ResponseError for TcpError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            TcpError::DomainError(de) => match de {
+                DomainError::AuthenticationError(_)
+                | DomainError::AuthenticationProtocolError(_) => StatusCode::UNAUTHORIZED,
+                DomainError::DatabaseError(_)
+                | DomainError::DatabaseTransactionError(_)
+                | DomainError::InternalError(_)
+                | DomainError::UnknownCryptoError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                DomainError::Base64DecodeError(_)
+                | DomainError::BinarySerializationError(_)
+                | DomainError::EntityNotFound(_) => StatusCode::BAD_REQUEST,
+            },
+            TcpError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            TcpError::NotFoundError(_) => StatusCode::NOT_FOUND,
+            TcpError::InternalServerError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            TcpError::UnauthorizedError(_) => StatusCode::UNAUTHORIZED,
+        }
     }
-    .body(error.to_string())
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code()).body(self.to_string())
+    }
+}
+
+pub(crate) fn error_to_http_response(error: TcpError) -> HttpResponse {
+    error.error_response()
 }
 
 async fn main_js_handler<Backend>(
@@ -112,6 +122,7 @@ async fn get_settings<Backend>(data: web::Data<AppState<Backend>>) -> HttpRespon
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn http_config<Backend>(
     cfg: &mut web::ServiceConfig,
     backend_handler: Backend,
@@ -120,6 +131,7 @@ fn http_config<Backend>(
     server_url: url::Url,
     assets_path: PathBuf,
     mail_options: MailOptions,
+    trusted_header_options: TrustedHeaderOptions,
 ) where
     Backend: TcpBackendHandler + BackendHandler + LoginHandler + OpaqueHandler + Clone + 'static,
 {
@@ -131,6 +143,7 @@ fn http_config<Backend>(
         server_url,
         assets_path: assets_path.clone(),
         mail_options,
+        trusted_header_options,
     }))
     .route(
         "/health",
@@ -175,6 +188,7 @@ pub(crate) struct AppState<Backend> {
     pub server_url: url::Url,
     pub assets_path: PathBuf,
     pub mail_options: MailOptions,
+    pub trusted_header_options: TrustedHeaderOptions,
 }
 
 impl<Backend: BackendHandler> AppState<Backend> {
@@ -214,6 +228,7 @@ where
     let server_url = config.http_url.0.clone();
     let assets_path = config.assets_path.clone();
     let mail_options = config.smtp_options.clone();
+    let trusted_header_options = config.trusted_header_options.clone();
     let verbose = config.verbose;
     if !assets_path.join("index.html").exists() {
         warn!(
@@ -233,6 +248,7 @@ where
                 let server_url = server_url.clone();
                 let assets_path = assets_path.clone();
                 let mail_options = mail_options.clone();
+                let trusted_header_options = trusted_header_options.clone();
                 HttpServiceBuilder::default()
                     .finish(map_config(
                         App::new()
@@ -249,6 +265,7 @@ where
                                     server_url,
                                     assets_path,
                                     mail_options,
+                                    trusted_header_options,
                                 )
                             }),
                         |_| AppConfig::default(),

--- a/server/tests/common/fixture.rs
+++ b/server/tests/common/fixture.rs
@@ -42,9 +42,15 @@ pub struct LLDAPFixture {
 const MAX_HEALTHCHECK_ATTEMPS: u8 = 10;
 
 impl LLDAPFixture {
+    #[allow(dead_code)] // The shared fixture is compiled separately for each integration test binary.
     pub fn new() -> Self {
+        Self::new_with_server_args(&[])
+    }
+
+    pub fn new_with_server_args(server_args: &[&str]) -> Self {
         let child = create_lldap_command("run")
             .arg("--verbose")
+            .args(server_args)
             .spawn()
             .expect("Unable to start server");
         let mut started = false;
@@ -73,6 +79,16 @@ impl LLDAPFixture {
             users: HashSet::new(),
             groups: HashMap::new(),
         }
+    }
+
+    #[allow(dead_code)] // The shared fixture is compiled separately for each integration test binary.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    #[allow(dead_code)] // The shared fixture is compiled separately for each integration test binary.
+    pub fn token(&self) -> &str {
+        &self.token
     }
 
     pub fn load_state(&mut self, state: &Vec<User>) {

--- a/server/tests/trusted_headers.rs
+++ b/server/tests/trusted_headers.rs
@@ -1,0 +1,143 @@
+mod common;
+
+use common::{
+    env,
+    fixture::{LLDAPFixture, User, new_id},
+};
+use lldap_auth::login;
+use reqwest::{
+    StatusCode,
+    blocking::{Client, Response},
+    header::{AUTHORIZATION, SET_COOKIE},
+};
+use serde_json::{Value, json};
+use serial_test::file_serial;
+
+const TRUSTED_HEADER: &str = "Remote-User";
+
+fn graphql_user(
+    client: &Client,
+    bearer: &str,
+    trusted_user: Option<&str>,
+    user_id: &str,
+) -> Response {
+    let mut request = client
+        .post(format!("{}/api/graphql", env::http_url()))
+        .header(AUTHORIZATION, format!("Bearer {bearer}"))
+        .json(&json!({
+            "query": "query($id: String!) { user(userId: $id) { id } }",
+            "variables": { "id": user_id },
+        }));
+    if let Some(trusted_user) = trusted_user {
+        request = request.header(TRUSTED_HEADER, trusted_user);
+    }
+    request.send().expect("GraphQL request failed")
+}
+
+#[test]
+#[file_serial]
+fn trusted_header_authentication_end_to_end() {
+    let mut fixture = LLDAPFixture::new_with_server_args(&[
+        "--trusted-header-enabled=true",
+        "--trusted-header-logout-url=https://proxy.example/logout",
+    ]);
+    let header_user = new_id(Some("trusted-header-"));
+    fixture.load_state(&vec![User::new(&header_user, vec![])]);
+
+    let response = graphql_user(
+        fixture.client(),
+        fixture.token(),
+        Some(&header_user),
+        "admin",
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response
+            .text()
+            .expect("failed to read GraphQL response")
+            .contains("Unauthorized access to user data"),
+        "the trusted-header identity should take precedence over the bearer token"
+    );
+
+    let response = graphql_user(
+        fixture.client(),
+        "invalid-token",
+        Some(&header_user),
+        &header_user,
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = response.json().expect("invalid GraphQL JSON response");
+    assert_eq!(body["data"]["user"]["id"], header_user);
+
+    let response = graphql_user(fixture.client(), fixture.token(), None, "admin");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = response.json().expect("invalid GraphQL JSON response");
+    assert_eq!(body["data"]["user"]["id"], "admin");
+
+    let response = fixture
+        .client()
+        .get(format!("{}/auth/refresh", env::http_url()))
+        .header(TRUSTED_HEADER, "admin")
+        .send()
+        .expect("refresh request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+    let set_cookies: Vec<_> = response
+        .headers()
+        .get_all(SET_COOKIE)
+        .iter()
+        .map(|value| {
+            value
+                .to_str()
+                .expect("invalid Set-Cookie header")
+                .to_owned()
+        })
+        .collect();
+    assert!(
+        set_cookies
+            .iter()
+            .any(|cookie| cookie.starts_with("token=") && cookie.contains("Max-Age=0"))
+    );
+    assert!(
+        set_cookies
+            .iter()
+            .any(|cookie| cookie.starts_with("refresh_token=") && cookie.contains("Max-Age=0"))
+    );
+    let body: login::ServerAuthResponse = response.json().expect("invalid refresh response");
+    let login::ServerAuthResponse::TrustedHeader(header_response) = body else {
+        panic!("trusted-header refresh returned the wrong response variant");
+    };
+    assert_eq!(header_response.user_id, "admin");
+    assert!(header_response.is_admin);
+    assert_eq!(
+        header_response.logout_url.as_deref(),
+        Some("https://proxy.example/logout")
+    );
+}
+
+#[test]
+#[file_serial]
+fn untrusted_proxy_does_not_fall_back_to_bearer_authentication() {
+    let fixture = LLDAPFixture::new_with_server_args(&[
+        "--trusted-header-enabled=true",
+        "--trusted-header-trusted-proxies=192.0.2.0/24",
+    ]);
+
+    let response = fixture
+        .client()
+        .post(format!("{}/api/graphql", env::http_url()))
+        .header(AUTHORIZATION, format!("Bearer {}", fixture.token()))
+        .header(TRUSTED_HEADER, "admin")
+        .header("X-Forwarded-For", "127.0.0.1")
+        .json(&json!({
+            "query": "query($id: String!) { user(userId: $id) { id } }",
+            "variables": { "id": "admin" },
+        }))
+        .send()
+        .expect("GraphQL request failed");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body = response.text().expect("failed to read error response");
+    assert!(body.contains("untrusted client IP"));
+    assert!(body.contains("trusted_proxies"));
+    assert!(body.contains("prevent direct client access"));
+}

--- a/set-password/src/main.rs
+++ b/set-password/src/main.rs
@@ -25,6 +25,18 @@ pub struct CliOpts {
     #[clap(short, long)]
     pub token: Option<String>,
 
+    /// Use trusted-header authentication instead of JWT/admin password.
+    #[clap(long)]
+    pub use_trusted_header: bool,
+
+    /// Trusted header name carrying the authenticated username.
+    #[clap(long, default_value = "Remote-User")]
+    pub trusted_header_name: String,
+
+    /// Trusted header value carrying the authenticated username.
+    #[clap(long, default_value = "admin")]
+    pub trusted_header_value: String,
+
     /// Username.
     #[clap(short, long)]
     pub username: String,
@@ -61,26 +73,41 @@ fn get_token(base_url: &Url, username: &str, password: &str) -> Result<String> {
     Ok(serde_json::from_str::<lldap_auth::login::ServerLoginResponse>(&response.text()?)?.token)
 }
 
-fn call_server(url: Url, token: &str, body: impl Serialize) -> Result<String> {
+#[derive(Debug, Clone)]
+pub struct TrustedHeaderAuth {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum Auth {
+    BearerToken(String),
+    TrustedHeader(TrustedHeaderAuth),
+}
+
+fn call_server(url: Url, auth: &Auth, body: impl Serialize) -> Result<String> {
     let client = reqwest::blocking::Client::new();
     let request = client
         .post(url)
         .header("Content-Type", "application/json")
-        .bearer_auth(token)
         .body(serde_json::to_string(&body)?);
+    let request = match auth {
+        Auth::BearerToken(token) => request.bearer_auth(token),
+        Auth::TrustedHeader(header) => request.header(&header.name, &header.value),
+    };
     let response = request.send()?.error_for_status()?;
     Ok(response.text()?)
 }
 
 pub fn register_start(
     base_url: &Url,
-    token: &str,
+    auth: &Auth,
     request: registration::ClientRegistrationStartRequest,
 ) -> Result<registration::ServerRegistrationStartResponse> {
     let request = Some(request);
     let data = call_server(
         append_to_url(base_url, "auth/opaque/register/start"),
-        token,
+        auth,
         request,
     )?;
     serde_json::from_str(&data).context("Could not parse response")
@@ -88,13 +115,13 @@ pub fn register_start(
 
 pub fn register_finish(
     base_url: &Url,
-    token: &str,
+    auth: &Auth,
     request: registration::ClientRegistrationFinishRequest,
 ) -> Result<()> {
     let request = Some(request);
     call_server(
         append_to_url(base_url, "auth/opaque/register/finish"),
-        token,
+        auth,
         request,
     )
     .map(|_| ())
@@ -103,10 +130,9 @@ pub fn register_finish(
 fn main() -> Result<()> {
     let opts = CliOpts::parse();
 
-    let password = match opts.password {
-        Some(v) => v,
-        None => env::var("LLDAP_USER_PASSWORD").unwrap_or_default(),
-    };
+    let password = opts
+        .password
+        .unwrap_or_else(|| env::var("LLDAP_USER_PASSWORD").unwrap_or_default());
 
     ensure!(
         opts.bypass_password_policy || password.len() >= 8,
@@ -116,12 +142,21 @@ fn main() -> Result<()> {
         opts.base_url.scheme() == "http" || opts.base_url.scheme() == "https",
         "Base URL should start with `http://` or `https://`"
     );
-    let token = match (opts.token.as_ref(), opts.admin_password.as_ref()) {
-        (Some(token), _) => token.clone(),
-        (None, Some(password)) => {
-            get_token(&opts.base_url, &opts.admin_username, password).context("While logging in")?
-        }
-        (None, None) => bail!("Either the token or the admin password is required"),
+    let auth = if opts.use_trusted_header {
+        Auth::TrustedHeader(TrustedHeaderAuth {
+            name: opts.trusted_header_name.clone(),
+            value: opts.trusted_header_value.clone(),
+        })
+    } else {
+        let token = match (opts.token.as_ref(), opts.admin_password.as_ref()) {
+            (Some(token), _) => token.clone(),
+            (None, Some(password)) => get_token(&opts.base_url, &opts.admin_username, password)
+                .context("While logging in")?,
+            (None, None) => bail!(
+                "Either the token or the admin password is required unless --use-trusted-header is set"
+            ),
+        };
+        Auth::BearerToken(token)
     };
 
     let mut rng = rand::rngs::OsRng;
@@ -132,7 +167,7 @@ fn main() -> Result<()> {
         username: opts.username.clone().into(),
         registration_start_request: registration_start_request.message,
     };
-    let res = register_start(&opts.base_url, &token, start_request)?;
+    let res = register_start(&opts.base_url, &auth, start_request)?;
 
     let registration_finish = opaque::client::registration::finish_registration(
         registration_start_request.state,
@@ -145,7 +180,7 @@ fn main() -> Result<()> {
         registration_upload: registration_finish.message,
     };
 
-    register_finish(&opts.base_url, &token, req)?;
+    register_finish(&opts.base_url, &auth, req)?;
 
     println!("Successfully changed {}'s password", &opts.username);
     Ok(())


### PR DESCRIPTION
This is a continuation of @Kumpelinus 's #1285 . I created a new PR to utilize the CI/auto-review on my PR. Let me know if it is favorable to close this and PR to @Kumpelinus 's repo.

1. Don't trust XFF headers, and use only the socket peer IP address
2. Decreased code duplication
3. Ensure the logout redirection actually work
4. Have the user specify CIDRs instead of single addresses, and validate the CIDR at startup
5. Prioritize trusted-header over JWT for GraphQL endpoints. ~The caveat is that some other endpoints  (OPAQUE-related) are still JWT-only.~ I also updated that.
