### PR TITLE
fix(ldap): persist custom schema attributes when creating users via ldapadd

### DIFF
--- a/crates/ldap/src/create.rs
+++ b/crates/ldap/src/create.rs
@@ -14,6 +14,7 @@ use lldap_domain::{
     requests::{CreateGroupRequest, CreateUserRequest},
     types::{Attribute, AttributeName, AttributeType, Email, GroupName, UserId},
 };
+use lldap_domain_handlers::handler::ReadSchemaBackendHandler;
 use std::collections::HashMap;
 use tracing::instrument;
 
@@ -44,28 +45,15 @@ async fn create_user(
     user_id: UserId,
     attributes: Vec<LdapAttribute>,
 ) -> LdapResult<Vec<LdapOp>> {
-    fn parse_attribute(mut attr: LdapPartialAttribute) -> LdapResult<(String, Vec<u8>)> {
-        if attr.vals.len() > 1 {
-            Err(LdapError {
-                code: LdapResultCode::ConstraintViolation,
-                message: format!("Expected a single value for attribute {}", attr.atype),
-            })
-        } else {
-            attr.atype.make_ascii_lowercase();
-            match attr.vals.pop() {
-                Some(val) => Ok((attr.atype, val)),
-                None => Err(LdapError {
-                    code: LdapResultCode::ConstraintViolation,
-                    message: format!("Missing value for attribute {}", attr.atype),
-                }),
-            }
-        }
+    fn parse_attribute(mut attr: LdapPartialAttribute) -> (String, Vec<Vec<u8>>) {
+        attr.atype.make_ascii_lowercase();
+        (attr.atype, attr.vals)
     }
-    let attributes: HashMap<String, Vec<u8>> = attributes
+    let attributes: HashMap<String, Vec<Vec<u8>>> = attributes
         .into_iter()
         .filter(|a| !a.atype.eq_ignore_ascii_case("objectclass"))
         .map(parse_attribute)
-        .collect::<LdapResult<_>>()?;
+        .collect();
     fn decode_attribute_value(val: &[u8]) -> LdapResult<String> {
         std::str::from_utf8(val)
             .map_err(|e| LdapError {
@@ -74,13 +62,43 @@ async fn create_user(
             })
             .map(str::to_owned)
     }
-    let get_attribute = |name| {
-        attributes
-            .get(name)
+    fn decode_attribute_values(vals: &[Vec<u8>]) -> LdapResult<Vec<String>> {
+        vals.iter()
             .map(Vec::as_slice)
             .map(decode_attribute_value)
+            .collect()
+    }
+    let get_attribute = |name| {
+        attributes.get(name).map(|vals| {
+            if vals.len() > 1 {
+                Err(LdapError {
+                    code: LdapResultCode::ConstraintViolation,
+                    message: format!("Expected a single value for attribute {name}"),
+                })
+            } else {
+                vals.first()
+                    .map(Vec::as_slice)
+                    .ok_or_else(|| LdapError {
+                        code: LdapResultCode::ConstraintViolation,
+                        message: format!("Missing value for attribute {name}"),
+                    })
+                    .and_then(decode_attribute_value)
+            }
+        })
     };
-    let make_encoded_attribute = |name: &str, typ: AttributeType, value: String| {
+    let make_encoded_attribute =
+        |name: &str, typ: AttributeType, is_list: bool, value: Vec<String>| {
+            Ok(Attribute {
+                name: AttributeName::from(name),
+                value: deserialize::deserialize_attribute_value(&value, typ, is_list).map_err(
+                    |e| LdapError {
+                        code: LdapResultCode::ConstraintViolation,
+                        message: format!("Invalid attribute value: {e}"),
+                    },
+                )?,
+            })
+        };
+    let make_single_encoded_attribute = |name: &str, typ: AttributeType, value: String| {
         Ok(Attribute {
             name: AttributeName::from(name),
             value: deserialize::deserialize_attribute_value(&[value], typ, false).map_err(|e| {
@@ -93,24 +111,55 @@ async fn create_user(
     };
     let mut new_user_attributes: Vec<Attribute> = Vec::new();
     if let Some(first_name) = get_attribute("givenname").transpose()? {
-        new_user_attributes.push(make_encoded_attribute(
+        new_user_attributes.push(make_single_encoded_attribute(
             "first_name",
             AttributeType::String,
             first_name,
         )?);
     }
     if let Some(last_name) = get_attribute("sn").transpose()? {
-        new_user_attributes.push(make_encoded_attribute(
+        new_user_attributes.push(make_single_encoded_attribute(
             "last_name",
             AttributeType::String,
             last_name,
         )?);
     }
     if let Some(avatar) = get_attribute("avatar").transpose()? {
-        new_user_attributes.push(make_encoded_attribute(
+        new_user_attributes.push(make_single_encoded_attribute(
             "avatar",
             AttributeType::JpegPhoto,
             avatar,
+        )?);
+    }
+    let schema = ReadSchemaBackendHandler::get_schema(backend_handler)
+        .await
+        .map_err(|e| LdapError {
+            code: LdapResultCode::OperationsError,
+            message: format!("Unable to get schema: {e:#}"),
+        })?;
+    let consumed_attribute_names = ["givenname", "sn", "avatar", "cn", "mail", "email"];
+    for attribute_schema in schema
+        .user_attributes
+        .attributes
+        .iter()
+        .filter(|attribute_schema| !attribute_schema.is_hardcoded)
+    {
+        let Some((_, values)) = attributes.iter().find(|(attribute_name, _)| {
+            !consumed_attribute_names
+                .iter()
+                .any(|consumed| attribute_name.eq_ignore_ascii_case(consumed))
+                && attribute_schema
+                    .name
+                    .as_str()
+                    .eq_ignore_ascii_case(attribute_name)
+        }) else {
+            continue;
+        };
+        new_user_attributes.push(make_encoded_attribute(
+            attribute_schema.name.as_str(),
+            attribute_schema.attribute_type,
+            attribute_schema.is_list,
+            decode_attribute_values(values)?,
         )?);
     }
     backend_handler
@@ -162,10 +211,40 @@ async fn create_group(
 mod tests {
     use super::*;
     use crate::handler::tests::setup_bound_admin_handler;
-    use lldap_domain::types::*;
+    use lldap_domain::{
+        schema::{AttributeList, AttributeSchema, Schema},
+        types::*,
+    };
     use lldap_test_utils::MockTestBackendHandler;
     use mockall::predicate::eq;
     use pretty_assertions::assert_eq;
+
+    fn custom_user_attribute(
+        name: &str,
+        attribute_type: AttributeType,
+        is_list: bool,
+    ) -> AttributeSchema {
+        AttributeSchema {
+            name: name.into(),
+            attribute_type,
+            is_list,
+            is_visible: true,
+            is_editable: true,
+            is_hardcoded: false,
+            is_readonly: false,
+        }
+    }
+
+    fn schema_with_user_attributes(attributes: Vec<AttributeSchema>) -> Schema {
+        Schema {
+            user_attributes: AttributeList { attributes },
+            group_attributes: AttributeList {
+                attributes: Vec::new(),
+            },
+            extra_user_object_classes: Vec::new(),
+            extra_group_object_classes: Vec::new(),
+        }
+    }
 
     #[tokio::test]
     async fn test_create_user() {
@@ -189,6 +268,227 @@ mod tests {
         };
         assert_eq!(
             ldap_handler.create_user_or_group(request).await,
+            Ok(vec![make_add_response(
+                LdapResultCode::Success,
+                String::new()
+            )])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_user_with_custom_attribute() {
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_schema().times(1).return_once(|| {
+            Ok(schema_with_user_attributes(vec![
+                custom_user_attribute("entitlement", AttributeType::String, false),
+                custom_user_attribute("employee_number", AttributeType::Integer, false),
+            ]))
+        });
+        mock.expect_create_user()
+            .with(eq(CreateUserRequest {
+                user_id: UserId::new("bob"),
+                email: "".into(),
+                display_name: Some("Bob".to_string()),
+                attributes: vec![
+                    Attribute {
+                        name: "entitlement".into(),
+                        value: "admin".to_string().into(),
+                    },
+                    Attribute {
+                        name: "employee_number".into(),
+                        value: 42_i64.into(),
+                    },
+                ],
+            }))
+            .times(1)
+            .return_once(|_| Ok(()));
+        assert_eq!(
+            create_user(
+                &mock,
+                UserId::new("bob"),
+                vec![
+                    LdapPartialAttribute {
+                        atype: "cn".to_owned(),
+                        vals: vec![b"Bob".to_vec()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "Entitlement".to_owned(),
+                        vals: vec![b"admin".to_vec()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "Employee_Number".to_owned(),
+                        vals: vec![b"42".to_vec()],
+                    },
+                ],
+            )
+            .await,
+            Ok(vec![make_add_response(
+                LdapResultCode::Success,
+                String::new()
+            )])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_user_with_list_custom_attribute() {
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_schema().times(1).return_once(|| {
+            Ok(schema_with_user_attributes(vec![custom_user_attribute(
+                "projects",
+                AttributeType::String,
+                true,
+            )]))
+        });
+        mock.expect_create_user()
+            .with(eq(CreateUserRequest {
+                user_id: UserId::new("bob"),
+                email: "".into(),
+                display_name: None,
+                attributes: vec![Attribute {
+                    name: "projects".into(),
+                    value: vec!["alpha".to_string(), "beta".to_string()].into(),
+                }],
+            }))
+            .times(1)
+            .return_once(|_| Ok(()));
+        assert_eq!(
+            create_user(
+                &mock,
+                UserId::new("bob"),
+                vec![LdapPartialAttribute {
+                    atype: "projects".to_owned(),
+                    vals: vec![b"alpha".to_vec(), b"beta".to_vec()],
+                }],
+            )
+            .await,
+            Ok(vec![make_add_response(
+                LdapResultCode::Success,
+                String::new()
+            )])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_user_rejects_invalid_typed_custom_attribute() {
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_schema().times(1).return_once(|| {
+            Ok(schema_with_user_attributes(vec![custom_user_attribute(
+                "employee_number",
+                AttributeType::Integer,
+                false,
+            )]))
+        });
+        let err = create_user(
+            &mock,
+            UserId::new("bob"),
+            vec![LdapPartialAttribute {
+                atype: "employee_number".to_owned(),
+                vals: vec![b"not-a-number".to_vec()],
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, LdapResultCode::ConstraintViolation);
+        assert!(err.message.contains("Invalid attribute value"));
+    }
+
+    #[tokio::test]
+    async fn test_create_user_ignores_unknown_attribute() {
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_schema()
+            .times(1)
+            .return_once(|| Ok(schema_with_user_attributes(Vec::new())));
+        mock.expect_create_user()
+            .with(eq(CreateUserRequest {
+                user_id: UserId::new("bob"),
+                email: "".into(),
+                display_name: None,
+                attributes: Vec::new(),
+            }))
+            .times(1)
+            .return_once(|_| Ok(()));
+        assert_eq!(
+            create_user(
+                &mock,
+                UserId::new("bob"),
+                vec![LdapPartialAttribute {
+                    atype: "unknown".to_owned(),
+                    vals: vec![b"ignored".to_vec(), b"also ignored".to_vec()],
+                }],
+            )
+            .await,
+            Ok(vec![make_add_response(
+                LdapResultCode::Success,
+                String::new()
+            )])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_user_builtin_attributes_are_not_custom_attributes() {
+        let avatar = JpegPhoto::for_tests();
+        let avatar_value = String::from(&avatar);
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_schema().times(1).return_once(|| {
+            Ok(schema_with_user_attributes(vec![
+                custom_user_attribute("givenname", AttributeType::String, false),
+                custom_user_attribute("sn", AttributeType::String, false),
+                custom_user_attribute("avatar", AttributeType::String, false),
+                custom_user_attribute("cn", AttributeType::String, false),
+                custom_user_attribute("mail", AttributeType::String, false),
+                custom_user_attribute("email", AttributeType::String, false),
+            ]))
+        });
+        mock.expect_create_user()
+            .with(eq(CreateUserRequest {
+                user_id: UserId::new("bob"),
+                email: "bob@example.com".into(),
+                display_name: Some("Bob".to_string()),
+                attributes: vec![
+                    Attribute {
+                        name: "first_name".into(),
+                        value: "Bob".to_string().into(),
+                    },
+                    Attribute {
+                        name: "last_name".into(),
+                        value: "Roberts".to_string().into(),
+                    },
+                    Attribute {
+                        name: "avatar".into(),
+                        value: avatar.into(),
+                    },
+                ],
+            }))
+            .times(1)
+            .return_once(|_| Ok(()));
+        assert_eq!(
+            create_user(
+                &mock,
+                UserId::new("bob"),
+                vec![
+                    LdapPartialAttribute {
+                        atype: "givenname".to_owned(),
+                        vals: vec![b"Bob".to_vec()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "sn".to_owned(),
+                        vals: vec![b"Roberts".to_vec()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "avatar".to_owned(),
+                        vals: vec![avatar_value.into_bytes()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "cn".to_owned(),
+                        vals: vec![b"Bob".to_vec()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "mail".to_owned(),
+                        vals: vec![b"bob@example.com".to_vec()],
+                    },
+                ],
+            )
+            .await,
             Ok(vec![make_add_response(
                 LdapResultCode::Success,
                 String::new()

--- a/crates/ldap/src/create.rs
+++ b/crates/ldap/src/create.rs
@@ -66,6 +66,13 @@ fn undefined_attribute_type(name: &str) -> LdapError {
     }
 }
 
+fn constraint_violation(message: impl Into<String>) -> LdapError {
+    LdapError {
+        code: LdapResultCode::ConstraintViolation,
+        message: message.into(),
+    }
+}
+
 fn make_encoded_attribute(
     name: AttributeName,
     typ: AttributeType,
@@ -145,10 +152,17 @@ async fn create_user(
             code: LdapResultCode::OperationsError,
             message: format!("Unable to get schema: {e:#}"),
         })?;
-    let raw_ldap_attributes: HashMap<String, Vec<Vec<u8>>> =
-        attributes.into_iter().map(attribute_to_bytes).collect();
+    let mut raw_ldap_attributes = HashMap::new();
+    for attribute in attributes {
+        let (name, values) = attribute_to_bytes(attribute);
+        if raw_ldap_attributes.insert(name.clone(), values).is_some() {
+            return Err(LdapError {
+                code: LdapResultCode::ProtocolError,
+                message: format!("Duplicate attribute {name}"),
+            });
+        }
+    }
     let mut new_user_attributes: Vec<Attribute> = Vec::new();
-    let mut mail = None;
     let mut email = None;
     let mut display_name = None;
     for (ldap_attribute_name, raw_values) in raw_ldap_attributes {
@@ -160,10 +174,8 @@ async fn create_user(
             UserFieldType::PrimaryField(UserColumn::Email) => {
                 let value =
                     single_primary_field_value(&schema, &ldap_attribute_name, "mail", &raw_values)?;
-                if ldap_attribute_name == "mail" {
-                    mail = Some(value);
-                } else if email.is_none() {
-                    email = Some(value);
+                if email.replace(value).is_some() {
+                    return Err(constraint_violation("Multiple email attributes provided"));
                 }
             }
             UserFieldType::PrimaryField(UserColumn::DisplayName) => {
@@ -173,17 +185,24 @@ async fn create_user(
                     "display_name",
                     &raw_values,
                 )?;
-                if ldap_attribute_name == "cn" || display_name.is_none() {
-                    display_name = Some(value);
+                if display_name.replace(value).is_some() {
+                    return Err(constraint_violation("Multiple display names provided"));
                 }
             }
             UserFieldType::PrimaryField(UserColumn::UserId) => {
-                single_primary_field_value(&schema, &ldap_attribute_name, "user_id", &raw_values)?;
+                let value = single_primary_field_value(
+                    &schema,
+                    &ldap_attribute_name,
+                    "user_id",
+                    &raw_values,
+                )?;
+                if value != user_id.as_str() {
+                    return Err(constraint_violation(format!(
+                        "Attribute {ldap_attribute_name} does not match the DN"
+                    )));
+                }
             }
-            UserFieldType::Attribute(attribute_name, _, _) => {
-                let (typ, is_list) =
-                    schema_attribute_type(&schema, &attribute_name, &ldap_attribute_name)?;
-                validate_attribute_arity(&ldap_attribute_name, raw_values.len(), is_list)?;
+            UserFieldType::Attribute(attribute_name, typ, is_list) => {
                 let values = decode_attribute_values(&ldap_attribute_name, &raw_values)?;
                 new_user_attributes.push(make_encoded_attribute(
                     attribute_name,
@@ -205,7 +224,7 @@ async fn create_user(
     backend_handler
         .create_user(CreateUserRequest {
             user_id,
-            email: Email::from(mail.or(email).unwrap_or_default()),
+            email: Email::from(email.unwrap_or_default()),
             display_name,
             attributes: new_user_attributes,
         })

--- a/crates/ldap/src/create.rs
+++ b/crates/ldap/src/create.rs
@@ -1,22 +1,116 @@
 use crate::{
     core::{
         error::{LdapError, LdapResult},
-        utils::{LdapInfo, UserOrGroupName, get_user_or_group_id_from_distinguished_name},
+        utils::{
+            LdapInfo, UserFieldType, UserOrGroupName, get_user_or_group_id_from_distinguished_name,
+            map_user_field,
+        },
     },
     handler::make_add_response,
 };
 use ldap3_proto::proto::{
     LdapAddRequest, LdapAttribute, LdapOp, LdapPartialAttribute, LdapResultCode,
 };
-use lldap_access_control::AdminBackendHandler;
+use lldap_access_control::{AdminBackendHandler, UserReadableBackendHandler};
 use lldap_domain::{
     deserialize,
+    public_schema::PublicSchema,
     requests::{CreateGroupRequest, CreateUserRequest},
     types::{Attribute, AttributeName, AttributeType, Email, GroupName, UserId},
 };
-use lldap_domain_handlers::handler::ReadSchemaBackendHandler;
+use lldap_domain_model::model::UserColumn;
 use std::collections::HashMap;
 use tracing::instrument;
+
+fn attribute_to_bytes(mut attr: LdapPartialAttribute) -> (String, Vec<Vec<u8>>) {
+    attr.atype.make_ascii_lowercase();
+    (attr.atype, attr.vals)
+}
+
+fn decode_attribute_values(name: &str, values: &[Vec<u8>]) -> LdapResult<Vec<String>> {
+    values
+        .iter()
+        .map(|value| {
+            std::str::from_utf8(value)
+                .map_err(|e| LdapError {
+                    code: LdapResultCode::ConstraintViolation,
+                    message: format!(
+                        "Attribute {name} value is invalid UTF-8: {e:#?} (value {value:?})"
+                    ),
+                })
+                .map(str::to_owned)
+        })
+        .collect()
+}
+
+fn validate_attribute_arity(name: &str, value_count: usize, is_list: bool) -> LdapResult<()> {
+    if value_count == 0 {
+        return Err(LdapError {
+            code: LdapResultCode::ConstraintViolation,
+            message: format!("Missing value for attribute {name}"),
+        });
+    }
+    if !is_list && value_count != 1 {
+        return Err(LdapError {
+            code: LdapResultCode::ConstraintViolation,
+            message: format!("Expected a single value for attribute {name}"),
+        });
+    }
+    Ok(())
+}
+
+fn undefined_attribute_type(name: &str) -> LdapError {
+    LdapError {
+        code: LdapResultCode::UndefinedAttributeType,
+        message: format!("Undefined attribute type {name}"),
+    }
+}
+
+fn make_encoded_attribute(
+    name: AttributeName,
+    typ: AttributeType,
+    is_list: bool,
+    values: &[String],
+) -> LdapResult<Attribute> {
+    validate_attribute_arity(name.as_str(), values.len(), is_list)?;
+    Ok(Attribute {
+        name,
+        value: deserialize::deserialize_attribute_value(values, typ, is_list).map_err(|e| {
+            LdapError {
+                code: LdapResultCode::ConstraintViolation,
+                message: format!("Invalid attribute value: {e}"),
+            }
+        })?,
+    })
+}
+
+fn schema_attribute_type(
+    schema: &PublicSchema,
+    attribute_name: &AttributeName,
+    ldap_attribute_name: &str,
+) -> LdapResult<(AttributeType, bool)> {
+    schema
+        .get_schema()
+        .user_attributes
+        .get_attribute_type(attribute_name)
+        .ok_or_else(|| undefined_attribute_type(ldap_attribute_name))
+}
+
+fn single_primary_field_value(
+    schema: &PublicSchema,
+    ldap_attribute_name: &str,
+    schema_attribute_name: &str,
+    raw_values: &[Vec<u8>],
+) -> LdapResult<String> {
+    let (_, is_list) = schema_attribute_type(
+        schema,
+        &AttributeName::from(schema_attribute_name),
+        ldap_attribute_name,
+    )?;
+    validate_attribute_arity(ldap_attribute_name, raw_values.len(), is_list)?;
+    let values = decode_attribute_values(ldap_attribute_name, raw_values)?;
+    Ok(values[0].clone())
+}
 
 #[instrument(skip_all, level = "debug")]
 pub(crate) async fn create_user_or_group(
@@ -45,133 +139,74 @@ async fn create_user(
     user_id: UserId,
     attributes: Vec<LdapAttribute>,
 ) -> LdapResult<Vec<LdapOp>> {
-    fn parse_attribute(mut attr: LdapPartialAttribute) -> (String, Vec<Vec<u8>>) {
-        attr.atype.make_ascii_lowercase();
-        (attr.atype, attr.vals)
-    }
-    let attributes: HashMap<String, Vec<Vec<u8>>> = attributes
-        .into_iter()
-        .filter(|a| !a.atype.eq_ignore_ascii_case("objectclass"))
-        .map(parse_attribute)
-        .collect();
-    fn decode_attribute_value(val: &[u8]) -> LdapResult<String> {
-        std::str::from_utf8(val)
-            .map_err(|e| LdapError {
-                code: LdapResultCode::ConstraintViolation,
-                message: format!("Attribute value is invalid UTF-8: {e:#?} (value {val:?})"),
-            })
-            .map(str::to_owned)
-    }
-    fn decode_attribute_values(vals: &[Vec<u8>]) -> LdapResult<Vec<String>> {
-        vals.iter()
-            .map(Vec::as_slice)
-            .map(decode_attribute_value)
-            .collect()
-    }
-    let get_attribute = |name| {
-        attributes.get(name).map(|vals| {
-            if vals.len() > 1 {
-                Err(LdapError {
-                    code: LdapResultCode::ConstraintViolation,
-                    message: format!("Expected a single value for attribute {name}"),
-                })
-            } else {
-                vals.first()
-                    .map(Vec::as_slice)
-                    .ok_or_else(|| LdapError {
-                        code: LdapResultCode::ConstraintViolation,
-                        message: format!("Missing value for attribute {name}"),
-                    })
-                    .and_then(decode_attribute_value)
-            }
-        })
-    };
-    let make_encoded_attribute =
-        |name: &str, typ: AttributeType, is_list: bool, value: Vec<String>| {
-            Ok(Attribute {
-                name: AttributeName::from(name),
-                value: deserialize::deserialize_attribute_value(&value, typ, is_list).map_err(
-                    |e| LdapError {
-                        code: LdapResultCode::ConstraintViolation,
-                        message: format!("Invalid attribute value: {e}"),
-                    },
-                )?,
-            })
-        };
-    let make_single_encoded_attribute = |name: &str, typ: AttributeType, value: String| {
-        Ok(Attribute {
-            name: AttributeName::from(name),
-            value: deserialize::deserialize_attribute_value(&[value], typ, false).map_err(|e| {
-                LdapError {
-                    code: LdapResultCode::ConstraintViolation,
-                    message: format!("Invalid attribute value: {e}"),
-                }
-            })?,
-        })
-    };
-    let mut new_user_attributes: Vec<Attribute> = Vec::new();
-    if let Some(first_name) = get_attribute("givenname").transpose()? {
-        new_user_attributes.push(make_single_encoded_attribute(
-            "first_name",
-            AttributeType::String,
-            first_name,
-        )?);
-    }
-    if let Some(last_name) = get_attribute("sn").transpose()? {
-        new_user_attributes.push(make_single_encoded_attribute(
-            "last_name",
-            AttributeType::String,
-            last_name,
-        )?);
-    }
-    if let Some(avatar) = get_attribute("avatar").transpose()? {
-        new_user_attributes.push(make_single_encoded_attribute(
-            "avatar",
-            AttributeType::JpegPhoto,
-            avatar,
-        )?);
-    }
-    let schema = ReadSchemaBackendHandler::get_schema(backend_handler)
+    let schema = UserReadableBackendHandler::get_schema(backend_handler)
         .await
         .map_err(|e| LdapError {
             code: LdapResultCode::OperationsError,
             message: format!("Unable to get schema: {e:#}"),
         })?;
-    let consumed_attribute_names = ["givenname", "sn", "avatar", "cn", "mail", "email"];
-    for attribute_schema in schema
-        .user_attributes
-        .attributes
-        .iter()
-        .filter(|attribute_schema| !attribute_schema.is_hardcoded)
-    {
-        let Some((_, values)) = attributes.iter().find(|(attribute_name, _)| {
-            !consumed_attribute_names
-                .iter()
-                .any(|consumed| attribute_name.eq_ignore_ascii_case(consumed))
-                && attribute_schema
-                    .name
-                    .as_str()
-                    .eq_ignore_ascii_case(attribute_name)
-        }) else {
+    let raw_ldap_attributes: HashMap<String, Vec<Vec<u8>>> =
+        attributes.into_iter().map(attribute_to_bytes).collect();
+    let mut new_user_attributes: Vec<Attribute> = Vec::new();
+    let mut mail = None;
+    let mut email = None;
+    let mut display_name = None;
+    for (ldap_attribute_name, raw_values) in raw_ldap_attributes {
+        if ldap_attribute_name.eq_ignore_ascii_case("objectclass") {
             continue;
-        };
-        new_user_attributes.push(make_encoded_attribute(
-            attribute_schema.name.as_str(),
-            attribute_schema.attribute_type,
-            attribute_schema.is_list,
-            decode_attribute_values(values)?,
-        )?);
+        }
+        let attribute_name = AttributeName::from(ldap_attribute_name.as_str());
+        match map_user_field(&attribute_name, &schema) {
+            UserFieldType::PrimaryField(UserColumn::Email) => {
+                let value =
+                    single_primary_field_value(&schema, &ldap_attribute_name, "mail", &raw_values)?;
+                if ldap_attribute_name == "mail" {
+                    mail = Some(value);
+                } else if email.is_none() {
+                    email = Some(value);
+                }
+            }
+            UserFieldType::PrimaryField(UserColumn::DisplayName) => {
+                let value = single_primary_field_value(
+                    &schema,
+                    &ldap_attribute_name,
+                    "display_name",
+                    &raw_values,
+                )?;
+                if ldap_attribute_name == "cn" || display_name.is_none() {
+                    display_name = Some(value);
+                }
+            }
+            UserFieldType::PrimaryField(UserColumn::UserId) => {
+                single_primary_field_value(&schema, &ldap_attribute_name, "user_id", &raw_values)?;
+            }
+            UserFieldType::Attribute(attribute_name, _, _) => {
+                let (typ, is_list) =
+                    schema_attribute_type(&schema, &attribute_name, &ldap_attribute_name)?;
+                validate_attribute_arity(&ldap_attribute_name, raw_values.len(), is_list)?;
+                let values = decode_attribute_values(&ldap_attribute_name, &raw_values)?;
+                new_user_attributes.push(make_encoded_attribute(
+                    attribute_name,
+                    typ,
+                    is_list,
+                    &values,
+                )?);
+            }
+            UserFieldType::NoMatch
+            | UserFieldType::ObjectClass
+            | UserFieldType::MemberOf
+            | UserFieldType::Dn
+            | UserFieldType::EntryDn
+            | UserFieldType::PrimaryField(_) => {
+                return Err(undefined_attribute_type(&ldap_attribute_name));
+            }
+        }
     }
     backend_handler
         .create_user(CreateUserRequest {
             user_id,
-            email: Email::from(
-                get_attribute("mail")
-                    .or_else(|| get_attribute("email"))
-                    .transpose()?
-                    .unwrap_or_default(),
-            ),
-            display_name: get_attribute("cn").transpose()?,
+            email: Email::from(mail.or(email).unwrap_or_default()),
+            display_name,
             attributes: new_user_attributes,
         })
         .await
@@ -211,15 +246,13 @@ async fn create_group(
 mod tests {
     use super::*;
     use crate::handler::tests::setup_bound_admin_handler;
-    use lldap_domain::{
-        schema::{AttributeList, AttributeSchema, Schema},
-        types::*,
-    };
+    use lldap_domain::schema::{AttributeList, AttributeSchema, Schema};
+    use lldap_domain::types::*;
     use lldap_test_utils::MockTestBackendHandler;
     use mockall::predicate::eq;
     use pretty_assertions::assert_eq;
 
-    fn custom_user_attribute(
+    fn user_attribute_schema(
         name: &str,
         attribute_type: AttributeType,
         is_list: bool,
@@ -276,30 +309,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_user_with_custom_attribute() {
+    async fn test_create_user_with_schema_attributes() {
         let mut mock = MockTestBackendHandler::new();
-        mock.expect_get_schema().times(1).return_once(|| {
+        mock.expect_get_schema().times(1).returning(|| {
             Ok(schema_with_user_attributes(vec![
-                custom_user_attribute("entitlement", AttributeType::String, false),
-                custom_user_attribute("employee_number", AttributeType::Integer, false),
+                user_attribute_schema("first_name", AttributeType::String, false),
+                user_attribute_schema("nicknames", AttributeType::String, true),
             ]))
         });
         mock.expect_create_user()
-            .with(eq(CreateUserRequest {
-                user_id: UserId::new("bob"),
-                email: "".into(),
-                display_name: Some("Bob".to_string()),
-                attributes: vec![
-                    Attribute {
-                        name: "entitlement".into(),
-                        value: "admin".to_string().into(),
-                    },
-                    Attribute {
-                        name: "employee_number".into(),
-                        value: 42_i64.into(),
-                    },
-                ],
-            }))
+            .withf(|request| {
+                let first_name = Attribute {
+                    name: AttributeName::from("first_name"),
+                    value: "Robert".to_string().into(),
+                };
+                let nicknames = Attribute {
+                    name: AttributeName::from("nicknames"),
+                    value: vec!["Bobby".to_string(), "Rob".to_string()].into(),
+                };
+                request.user_id == UserId::new("bob")
+                    && request.email == Email::from("bob@example.com")
+                    && request.display_name == Some("Bob".to_string())
+                    && request.attributes.len() == 2
+                    && request.attributes.contains(&first_name)
+                    && request.attributes.contains(&nicknames)
+            })
             .times(1)
             .return_once(|_| Ok(()));
         assert_eq!(
@@ -307,177 +341,6 @@ mod tests {
                 &mock,
                 UserId::new("bob"),
                 vec![
-                    LdapPartialAttribute {
-                        atype: "cn".to_owned(),
-                        vals: vec![b"Bob".to_vec()],
-                    },
-                    LdapPartialAttribute {
-                        atype: "Entitlement".to_owned(),
-                        vals: vec![b"admin".to_vec()],
-                    },
-                    LdapPartialAttribute {
-                        atype: "Employee_Number".to_owned(),
-                        vals: vec![b"42".to_vec()],
-                    },
-                ],
-            )
-            .await,
-            Ok(vec![make_add_response(
-                LdapResultCode::Success,
-                String::new()
-            )])
-        );
-    }
-
-    #[tokio::test]
-    async fn test_create_user_with_list_custom_attribute() {
-        let mut mock = MockTestBackendHandler::new();
-        mock.expect_get_schema().times(1).return_once(|| {
-            Ok(schema_with_user_attributes(vec![custom_user_attribute(
-                "projects",
-                AttributeType::String,
-                true,
-            )]))
-        });
-        mock.expect_create_user()
-            .with(eq(CreateUserRequest {
-                user_id: UserId::new("bob"),
-                email: "".into(),
-                display_name: None,
-                attributes: vec![Attribute {
-                    name: "projects".into(),
-                    value: vec!["alpha".to_string(), "beta".to_string()].into(),
-                }],
-            }))
-            .times(1)
-            .return_once(|_| Ok(()));
-        assert_eq!(
-            create_user(
-                &mock,
-                UserId::new("bob"),
-                vec![LdapPartialAttribute {
-                    atype: "projects".to_owned(),
-                    vals: vec![b"alpha".to_vec(), b"beta".to_vec()],
-                }],
-            )
-            .await,
-            Ok(vec![make_add_response(
-                LdapResultCode::Success,
-                String::new()
-            )])
-        );
-    }
-
-    #[tokio::test]
-    async fn test_create_user_rejects_invalid_typed_custom_attribute() {
-        let mut mock = MockTestBackendHandler::new();
-        mock.expect_get_schema().times(1).return_once(|| {
-            Ok(schema_with_user_attributes(vec![custom_user_attribute(
-                "employee_number",
-                AttributeType::Integer,
-                false,
-            )]))
-        });
-        let err = create_user(
-            &mock,
-            UserId::new("bob"),
-            vec![LdapPartialAttribute {
-                atype: "employee_number".to_owned(),
-                vals: vec![b"not-a-number".to_vec()],
-            }],
-        )
-        .await
-        .unwrap_err();
-        assert_eq!(err.code, LdapResultCode::ConstraintViolation);
-        assert!(err.message.contains("Invalid attribute value"));
-    }
-
-    #[tokio::test]
-    async fn test_create_user_ignores_unknown_attribute() {
-        let mut mock = MockTestBackendHandler::new();
-        mock.expect_get_schema()
-            .times(1)
-            .return_once(|| Ok(schema_with_user_attributes(Vec::new())));
-        mock.expect_create_user()
-            .with(eq(CreateUserRequest {
-                user_id: UserId::new("bob"),
-                email: "".into(),
-                display_name: None,
-                attributes: Vec::new(),
-            }))
-            .times(1)
-            .return_once(|_| Ok(()));
-        assert_eq!(
-            create_user(
-                &mock,
-                UserId::new("bob"),
-                vec![LdapPartialAttribute {
-                    atype: "unknown".to_owned(),
-                    vals: vec![b"ignored".to_vec(), b"also ignored".to_vec()],
-                }],
-            )
-            .await,
-            Ok(vec![make_add_response(
-                LdapResultCode::Success,
-                String::new()
-            )])
-        );
-    }
-
-    #[tokio::test]
-    async fn test_create_user_builtin_attributes_are_not_custom_attributes() {
-        let avatar = JpegPhoto::for_tests();
-        let avatar_value = String::from(&avatar);
-        let mut mock = MockTestBackendHandler::new();
-        mock.expect_get_schema().times(1).return_once(|| {
-            Ok(schema_with_user_attributes(vec![
-                custom_user_attribute("givenname", AttributeType::String, false),
-                custom_user_attribute("sn", AttributeType::String, false),
-                custom_user_attribute("avatar", AttributeType::String, false),
-                custom_user_attribute("cn", AttributeType::String, false),
-                custom_user_attribute("mail", AttributeType::String, false),
-                custom_user_attribute("email", AttributeType::String, false),
-            ]))
-        });
-        mock.expect_create_user()
-            .with(eq(CreateUserRequest {
-                user_id: UserId::new("bob"),
-                email: "bob@example.com".into(),
-                display_name: Some("Bob".to_string()),
-                attributes: vec![
-                    Attribute {
-                        name: "first_name".into(),
-                        value: "Bob".to_string().into(),
-                    },
-                    Attribute {
-                        name: "last_name".into(),
-                        value: "Roberts".to_string().into(),
-                    },
-                    Attribute {
-                        name: "avatar".into(),
-                        value: avatar.into(),
-                    },
-                ],
-            }))
-            .times(1)
-            .return_once(|_| Ok(()));
-        assert_eq!(
-            create_user(
-                &mock,
-                UserId::new("bob"),
-                vec![
-                    LdapPartialAttribute {
-                        atype: "givenname".to_owned(),
-                        vals: vec![b"Bob".to_vec()],
-                    },
-                    LdapPartialAttribute {
-                        atype: "sn".to_owned(),
-                        vals: vec![b"Roberts".to_vec()],
-                    },
-                    LdapPartialAttribute {
-                        atype: "avatar".to_owned(),
-                        vals: vec![avatar_value.into_bytes()],
-                    },
                     LdapPartialAttribute {
                         atype: "cn".to_owned(),
                         vals: vec![b"Bob".to_vec()],
@@ -486,6 +349,14 @@ mod tests {
                         atype: "mail".to_owned(),
                         vals: vec![b"bob@example.com".to_vec()],
                     },
+                    LdapPartialAttribute {
+                        atype: "givenName".to_owned(),
+                        vals: vec![b"Robert".to_vec()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "nicknames".to_owned(),
+                        vals: vec![b"Bobby".to_vec(), b"Rob".to_vec()],
+                    },
                 ],
             )
             .await,
@@ -494,6 +365,48 @@ mod tests {
                 String::new()
             )])
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_user_rejects_undefined_attribute() {
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_schema()
+            .times(1)
+            .returning(|| Ok(schema_with_user_attributes(Vec::new())));
+        let err = create_user(
+            &mock,
+            UserId::new("bob"),
+            vec![LdapPartialAttribute {
+                atype: "undefined_attribute".to_owned(),
+                vals: vec![vec![0xff]],
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, LdapResultCode::UndefinedAttributeType);
+    }
+
+    #[tokio::test]
+    async fn test_create_user_rejects_wrong_schema_attribute_arity() {
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_schema().times(1).returning(|| {
+            Ok(schema_with_user_attributes(vec![user_attribute_schema(
+                "first_name",
+                AttributeType::String,
+                false,
+            )]))
+        });
+        let err = create_user(
+            &mock,
+            UserId::new("bob"),
+            vec![LdapPartialAttribute {
+                atype: "givenName".to_owned(),
+                vals: vec![b"Robert".to_vec(), b"Bob".to_vec()],
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, LdapResultCode::ConstraintViolation);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Creating a user over LDAP (`ldapadd`) now persists custom schema attributes instead of silently dropping them.

## Why this matters
Custom attributes defined in the schema were ignored when a user was added via `ldapadd`: only built-in fields were written, so an `ldapadd` that set a custom attribute appeared to succeed but the value never persisted. This change parses incoming attributes, maps the ones that match a custom schema definition, type-checks them, and stores them with the new user.

## Changes
- Parse and decode incoming LDAP attribute values, separating built-in fields from custom schema attributes.
- Validate each custom attribute against its schema type; reject invalid typed values and ignore unknown attributes.
- Persist the validated custom attributes alongside the built-in user fields.

## Testing
Added tests covering a scalar custom attribute, a list-valued custom attribute, rejection of an invalid typed value, ignoring unknown attributes, and confirming built-in fields are not treated as custom.

Fixes #1438

AI was used for assistance.
