### PR TITLE
Support LDAP equality filters on list user attributes

### DIFF
--- a/crates/domain-handlers/src/handler.rs
+++ b/crates/domain-handlers/src/handler.rs
@@ -79,6 +79,7 @@ pub enum UserRequestFilter {
     UserIdSubString(SubStringFilter),
     Equality(UserColumn, String),
     AttributeEquality(AttributeName, AttributeValue),
+    AttributeListContains(AttributeName, AttributeValue),
     SubString(UserColumn, SubStringFilter),
     // Check if a user belongs to a group identified by name.
     MemberOf(GroupName),

--- a/crates/ldap/src/core/user.rs
+++ b/crates/ldap/src/core/user.rs
@@ -183,23 +183,21 @@ fn get_user_attribute_equality_filter(
     is_list: bool,
     value: &str,
 ) -> LdapResult<UserRequestFilter> {
-    if is_list {
-        return Err(LdapError {
-            code: LdapResultCode::UnwillingToPerform,
-            message: format!(
-                "Equality filter on list attribute \"{}\" is not supported",
-                field
-            ),
-        });
-    }
     let value_lc = value.to_ascii_lowercase();
-    let serialized_value = deserialize_attribute_value(&[value.to_owned()], typ, false);
-    let serialized_value_lc = deserialize_attribute_value(&[value_lc.to_owned()], typ, false);
+    let serialized_value = deserialize_attribute_value(&[value.to_owned()], typ, is_list);
+    let serialized_value_lc = deserialize_attribute_value(&[value_lc.to_owned()], typ, is_list);
     match (serialized_value, serialized_value_lc) {
-        (Ok(v), Ok(v_lc)) => Ok(UserRequestFilter::Or(vec![
-            UserRequestFilter::AttributeEquality(field.clone(), v),
-            UserRequestFilter::AttributeEquality(field.clone(), v_lc),
-        ])),
+        (Ok(v), Ok(v_lc)) => {
+            let make_filter = if is_list {
+                UserRequestFilter::AttributeListContains
+            } else {
+                UserRequestFilter::AttributeEquality
+            };
+            Ok(UserRequestFilter::Or(vec![
+                make_filter(field.clone(), v),
+                make_filter(field.clone(), v_lc),
+            ]))
+        }
         (Ok(_), Err(e)) => {
             warn!("Invalid value for attribute {} (lowercased): {}", field, e);
             Ok(UserRequestFilter::False)
@@ -796,7 +794,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_equality_filter_on_list_user_attribute_returns_error() {
+    async fn test_equality_filter_on_list_user_attribute() {
         use lldap_domain::schema::{AttributeList, AttributeSchema, Schema};
         let mut mock = MockTestBackendHandler::new();
         mock.expect_get_schema().returning(|| {
@@ -819,6 +817,22 @@ mod tests {
                 extra_group_object_classes: Vec::new(),
             })
         });
+        mock.expect_list_users()
+            .with(
+                eq(Some(UserRequestFilter::Or(vec![
+                    UserRequestFilter::AttributeListContains(
+                        AttributeName::from("mailalias"),
+                        vec!["alias@example.com".to_string()].into(),
+                    ),
+                    UserRequestFilter::AttributeListContains(
+                        AttributeName::from("mailalias"),
+                        vec!["alias@example.com".to_string()].into(),
+                    ),
+                ]))),
+                eq(false),
+            )
+            .times(1)
+            .return_once(|_, _| Ok(vec![]));
         let ldap_handler = setup_bound_admin_handler(mock).await;
         let request = make_user_search_request(
             LdapFilter::Equality("mailalias".to_string(), "alias@example.com".to_string()),
@@ -826,11 +840,7 @@ mod tests {
         );
         assert_eq!(
             ldap_handler.do_search_or_dse(&request).await,
-            Err(LdapError {
-                code: LdapResultCode::UnwillingToPerform,
-                message: r#"Equality filter on list attribute "mailalias" is not supported"#
-                    .to_string(),
-            })
+            Ok(vec![make_search_success()])
         );
     }
 

--- a/crates/sql-backend-handler/src/sql_user_backend_handler.rs
+++ b/crates/sql-backend-handler/src/sql_user_backend_handler.rs
@@ -260,7 +260,9 @@ fn user_matches_filter(user_and_groups: &UserAndGroups, filter: &UserRequestFilt
         MemberOf(group) => user_and_groups.groups.as_ref().is_some_and(|groups| {
             groups
                 .iter()
-                .any(|group_details| group_details.display_name == *group)
+                .any(|group_details| {
+                    group_details.display_name.as_str().eq_ignore_ascii_case(group.as_str())
+                })
         }),
         MemberOfId(group_id) => user_and_groups.groups.as_ref().is_some_and(|groups| {
             groups

--- a/crates/sql-backend-handler/src/sql_user_backend_handler.rs
+++ b/crates/sql-backend-handler/src/sql_user_backend_handler.rs
@@ -4,8 +4,8 @@ use lldap_domain::{
     requests::{CreateUserRequest, UpdateUserRequest},
     schema::Schema,
     types::{
-        Attribute, AttributeName, GroupDetails, GroupId, Serialized, User, UserAndGroups, UserId,
-        Uuid,
+        Attribute, AttributeName, AttributeValue, Cardinality, GroupDetails, GroupId, Serialized,
+        User, UserAndGroups, UserId, Uuid,
     },
 };
 use lldap_domain_handlers::handler::{
@@ -92,6 +92,7 @@ fn get_user_filter_expr(filter: UserRequestFilter) -> Cond {
             }
         }
         AttributeEquality(column, value) => attribute_condition(column, Some(value.into())),
+        AttributeListContains(_, _) => bool_to_expr(true),
         MemberOf(group) => user_id_subcondition(
             Expr::col((group_table, GroupColumn::LowercaseDisplayName))
                 .eq(group.as_str().to_lowercase())
@@ -111,6 +112,165 @@ fn get_user_filter_expr(filter: UserRequestFilter) -> Cond {
                 .into_condition()
         }
         CustomAttributePresent(name) => attribute_condition(name, None),
+    }
+}
+
+fn filter_has_attribute_list_contains(filter: &UserRequestFilter) -> bool {
+    use UserRequestFilter::*;
+    match filter {
+        And(filters) | Or(filters) => filters.iter().any(filter_has_attribute_list_contains),
+        Not(filter) => filter_has_attribute_list_contains(filter),
+        AttributeListContains(_, _) => true,
+        True
+        | False
+        | UserId(_)
+        | UserIdSubString(_)
+        | Equality(_, _)
+        | AttributeEquality(_, _)
+        | SubString(_, _)
+        | MemberOf(_)
+        | MemberOfId(_)
+        | CustomAttributePresent(_) => false,
+    }
+}
+
+fn get_user_prefilter_expr(filter: UserRequestFilter) -> Cond {
+    use UserRequestFilter::*;
+    match filter {
+        Not(filter) if filter_has_attribute_list_contains(&filter) => {
+            SimpleExpr::Value(true.into()).into_condition()
+        }
+        And(filters) => filters
+            .into_iter()
+            .map(get_user_prefilter_expr)
+            .fold(Cond::all(), Cond::add),
+        Or(filters) => filters
+            .into_iter()
+            .map(get_user_prefilter_expr)
+            .fold(Cond::any(), Cond::add),
+        filter => get_user_filter_expr(filter),
+    }
+}
+
+fn substring_matches(
+    value: &str,
+    filter: &lldap_domain_handlers::handler::SubStringFilter,
+) -> bool {
+    let value = value.to_ascii_lowercase();
+    let initial = filter.initial.as_ref().map(|s| s.to_ascii_lowercase());
+    let any = filter
+        .any
+        .iter()
+        .map(|s| s.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    let final_ = filter.final_.as_ref().map(|s| s.to_ascii_lowercase());
+
+    let mut offset = 0;
+    if let Some(initial) = initial {
+        if !value.starts_with(&initial) {
+            return false;
+        }
+        offset = initial.len();
+    }
+    for part in any {
+        let Some(index) = value[offset..].find(&part) else {
+            return false;
+        };
+        offset += index + part.len();
+    }
+    final_
+        .map(|final_| value.ends_with(&final_))
+        .unwrap_or(true)
+}
+
+fn attribute_value_contains(attribute_value: &AttributeValue, needle: &AttributeValue) -> bool {
+    match (attribute_value, needle) {
+        (
+            AttributeValue::String(Cardinality::Unbounded(values)),
+            AttributeValue::String(Cardinality::Unbounded(needles)),
+        ) => needles.iter().any(|needle| values.contains(needle)),
+        (
+            AttributeValue::Integer(Cardinality::Unbounded(values)),
+            AttributeValue::Integer(Cardinality::Unbounded(needles)),
+        ) => needles.iter().any(|needle| values.contains(needle)),
+        (
+            AttributeValue::JpegPhoto(Cardinality::Unbounded(values)),
+            AttributeValue::JpegPhoto(Cardinality::Unbounded(needles)),
+        ) => needles.iter().any(|needle| values.contains(needle)),
+        (
+            AttributeValue::DateTime(Cardinality::Unbounded(values)),
+            AttributeValue::DateTime(Cardinality::Unbounded(needles)),
+        ) => needles.iter().any(|needle| values.contains(needle)),
+        _ => false,
+    }
+}
+
+fn user_matches_filter(user_and_groups: &UserAndGroups, filter: &UserRequestFilter) -> bool {
+    use UserRequestFilter::*;
+    let user = &user_and_groups.user;
+    match filter {
+        True => true,
+        False => false,
+        And(filters) => filters
+            .iter()
+            .all(|filter| user_matches_filter(user_and_groups, filter)),
+        Or(filters) => filters
+            .iter()
+            .any(|filter| user_matches_filter(user_and_groups, filter)),
+        Not(filter) => !user_matches_filter(user_and_groups, filter),
+        UserId(user_id) => &user.user_id == user_id,
+        UserIdSubString(filter) => substring_matches(user.user_id.as_str(), filter),
+        Equality(column, value) => match column {
+            UserColumn::UserId => user.user_id.as_str() == value,
+            UserColumn::Email | UserColumn::LowercaseEmail => {
+                user.email.as_str().to_ascii_lowercase() == value.to_ascii_lowercase()
+            }
+            UserColumn::DisplayName => user.display_name.as_deref() == Some(value.as_str()),
+            UserColumn::Uuid => user.uuid.to_string() == *value,
+            UserColumn::CreationDate => user.creation_date.to_string() == *value,
+            UserColumn::ModifiedDate => user.modified_date.to_string() == *value,
+            UserColumn::PasswordModifiedDate => user.password_modified_date.to_string() == *value,
+            UserColumn::PasswordHash | UserColumn::TotpSecret | UserColumn::MfaType => false,
+        },
+        AttributeEquality(name, value) => user
+            .attributes
+            .iter()
+            .any(|attribute| attribute.name == *name && attribute.value == *value),
+        AttributeListContains(name, value) => user.attributes.iter().any(|attribute| {
+            attribute.name == *name && attribute_value_contains(&attribute.value, value)
+        }),
+        SubString(column, filter) => match column {
+            UserColumn::UserId => substring_matches(user.user_id.as_str(), filter),
+            UserColumn::Email | UserColumn::LowercaseEmail => {
+                substring_matches(user.email.as_str(), filter)
+            }
+            UserColumn::DisplayName => user
+                .display_name
+                .as_deref()
+                .map(|value| substring_matches(value, filter))
+                .unwrap_or(false),
+            UserColumn::Uuid => substring_matches(&user.uuid.to_string(), filter),
+            UserColumn::CreationDate => substring_matches(&user.creation_date.to_string(), filter),
+            UserColumn::ModifiedDate => substring_matches(&user.modified_date.to_string(), filter),
+            UserColumn::PasswordModifiedDate => {
+                substring_matches(&user.password_modified_date.to_string(), filter)
+            }
+            UserColumn::PasswordHash | UserColumn::TotpSecret | UserColumn::MfaType => false,
+        },
+        MemberOf(group) => user_and_groups.groups.as_ref().is_some_and(|groups| {
+            groups
+                .iter()
+                .any(|group_details| group_details.display_name == *group)
+        }),
+        MemberOfId(group_id) => user_and_groups.groups.as_ref().is_some_and(|groups| {
+            groups
+                .iter()
+                .any(|group_details| group_details.group_id == *group_id)
+        }),
+        CustomAttributePresent(name) => user
+            .attributes
+            .iter()
+            .any(|attribute| attribute.name == *name),
     }
 }
 
@@ -134,8 +294,19 @@ impl UserListerBackendHandler for SqlBackendHandler {
         // To simplify the query, we always fetch groups. TODO: cleanup.
         _get_groups: bool,
     ) -> Result<Vec<UserAndGroups>> {
+        let needs_attribute_list_filter = filters
+            .as_ref()
+            .map(filter_has_attribute_list_contains)
+            .unwrap_or(false);
+        let original_filters = filters.clone();
         let filters = filters
-            .map(get_user_filter_expr)
+            .map(|filter| {
+                if needs_attribute_list_filter {
+                    get_user_prefilter_expr(filter)
+                } else {
+                    get_user_filter_expr(filter)
+                }
+            })
             .unwrap_or_else(|| SimpleExpr::Value(true.into()).into_condition());
         let mut users: Vec<_> = model::User::find()
             .filter(filters.clone())
@@ -183,6 +354,11 @@ impl UserListerBackendHandler for SqlBackendHandler {
                     )
                 })
                 .collect::<Result<Vec<_>>>()?;
+        }
+        if needs_attribute_list_filter {
+            if let Some(filters) = original_filters {
+                users.retain(|user| user_matches_filter(user, &filters));
+            }
         }
         Ok(users)
     }
@@ -534,6 +710,69 @@ mod tests {
         )
         .await;
         assert_eq!(users, vec!["bob"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_users_attribute_list_contains_filter() {
+        use lldap_domain::{
+            requests::{CreateAttributeRequest, UpdateUserRequest},
+            types::AttributeType,
+        };
+        use lldap_domain_handlers::handler::{SchemaBackendHandler, UserBackendHandler};
+
+        let fixture = TestFixture::new().await;
+        fixture
+            .handler
+            .add_user_attribute(CreateAttributeRequest {
+                name: "mailalias".into(),
+                attribute_type: AttributeType::String,
+                is_list: true,
+                is_visible: true,
+                is_editable: true,
+            })
+            .await
+            .unwrap();
+        fixture
+            .handler
+            .update_user(UpdateUserRequest {
+                user_id: UserId::new("bob"),
+                email: None,
+                display_name: None,
+                delete_attributes: Vec::new(),
+                insert_attributes: vec![Attribute {
+                    name: "mailalias".into(),
+                    value: vec![
+                        "alexa@rowland.net.au".to_string(),
+                        "bob.alias@example.com".to_string(),
+                    ]
+                    .into(),
+                }],
+            })
+            .await
+            .unwrap();
+
+        let users = get_user_names(
+            &fixture.handler,
+            Some(UserRequestFilter::AttributeListContains(
+                AttributeName::from("mailalias"),
+                vec!["alexa@rowland.net.au".to_string()].into(),
+            )),
+        )
+        .await;
+        assert_eq!(users, vec!["bob"]);
+
+        let users = get_user_names(
+            &fixture.handler,
+            Some(UserRequestFilter::Or(vec![
+                UserRequestFilter::AttributeListContains(
+                    AttributeName::from("mailalias"),
+                    vec!["missing@example.com".to_string()].into(),
+                ),
+                UserRequestFilter::UserId(UserId::new("patrick")),
+            ])),
+        )
+        .await;
+        assert_eq!(users, vec!["patrick"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Support LDAP equality filters on list-valued custom user attributes

## Summary

This change allows LDAP equality filters to match values inside list-valued custom user attributes.

The motivating case is Stalwart Mail Server recipient lookup against LLDAP with a filter like:

```ldap
(&(objectClass=person)(|(mail=?)(mailalias=?)))
```

`mailalias` is commonly configured as a custom list attribute. Before this change, LLDAP rejected equality filters on list-valued custom user attributes with `UnwillingToPerform`, so an LDAP client could not resolve a user by any of their alias addresses. That prevented Stalwart from treating alias recipients as local users when aliases were stored only in LLDAP.

After this change, an equality filter such as:

```ldap
(mailalias=alias@example.com)
```

matches a user when `alias@example.com` is one of the values in that user's `mailalias` list.

## What changed

- Added a new internal user request filter variant, `AttributeListContains`, to represent equality matching against a list-valued custom attribute.
- Updated LDAP user filter parsing so equality filters on list-valued custom user attributes are accepted instead of rejected.
- Preserved the existing case-insensitive behavior by building an OR filter with the supplied value and its ASCII-lowercased form.
- Updated the SQL backend to support `AttributeListContains` by:
  - using a broad SQL prefilter when a list-membership check is present, and
  - applying the exact list-membership predicate in memory after users and custom attributes are loaded.
- Added regression coverage for:
  - LDAP equality filters on list-valued custom user attributes, and
  - SQL-backed user listing with `AttributeListContains`, including OR-composed filters.

## Why the SQL backend filters in memory

Custom list attributes are stored as serialized attribute values, and the existing SQL attribute equality path compares whole serialized values. For a list-valued attribute that would only match if the entire serialized list equals the query value, which is not the LDAP equality semantics clients expect.

To avoid changing the schema or adding database-specific JSON/list queries, this patch uses SQL only as a safe prefilter and then evaluates the precise list-membership condition against the loaded `UserAndGroups` records. This keeps the behavior correct for nested `AND`, `OR`, and `NOT` filters while keeping the change localized.

## Validation

- Built a Docker image from this branch and deployed it against a live LLDAP/Stalwart setup.
- Verified direct LDAP searches such as `(mailalias=alias@example.com)` return the expected user when the alias is one of several `mailalias` values.
- Verified Stalwart's mailbox lookup filter `(&(objectClass=person)(|(mail=?)(mailalias=?)))` can resolve aliases that are not the first `mailalias` value.
- Added focused unit tests for the LDAP filter parser and SQL backend list-membership filtering.

Targeted local test commands:

```bash
cargo fmt --check --all
cargo test -p lldap_ldap test_equality_filter_on_list_user_attribute
cargo test -p lldap_sql_backend_handler test_list_users_attribute_list_contains_filter
```

## Notes

This change is intentionally limited to equality matching for list-valued custom user attributes. It does not alter custom attribute storage, LDAP schema generation, or substring matching behavior.
