### PR TITLE
lldap-ha-auth: show meaningful error if display name is not set

### DIFF
--- a/example_configs/lldap-ha-auth.sh
+++ b/example_configs/lldap-ha-auth.sh
@@ -46,6 +46,10 @@ if [[ -z "$3" ]]; then
 	exit 1
 fi
 
+if [[ "$4" = "-v" ]]; then
+	set -x
+fi
+
 RESPONSE=$(curl -f -s -X POST -m "$TIMEOUT" -H "Content-type: application/json" -d '{"username":"'"$username"'","password":"'"$password"'"}' "$SERVER_URL/auth/simple/login")
 if [[ $? -ne 0 ]]; then
     log "Auth failed"

--- a/example_configs/lldap-ha-auth.sh
+++ b/example_configs/lldap-ha-auth.sh
@@ -36,6 +36,16 @@ elif [ ! -z "$USERNAME_PATTERN" ]; then
 	fi
 fi
 
+if [[ -z "$2" ]]; then
+	log "No user group given"
+	exit 1
+fi
+
+if [[ -z "$3" ]]; then
+	log "No admin group given"
+	exit 1
+fi
+
 RESPONSE=$(curl -f -s -X POST -m "$TIMEOUT" -H "Content-type: application/json" -d '{"username":"'"$username"'","password":"'"$password"'"}' "$SERVER_URL/auth/simple/login")
 if [[ $? -ne 0 ]]; then
     log "Auth failed"
@@ -59,9 +69,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-if [[ ! -z "$2" ]] && ! jq -e '.groups|map(.displayName)|index("'"$2"'")' <<< $USER_JSON > /dev/null 2>&1; then
-	log "User is not in group '$2'"
-	exit 1
+jq -e '.groups|map(.displayName)|index("'"$2"'")' <<< "$USER_JSON" > /dev/null 2>&1
+IS_USER_CODE=$?
+jq -e '.groups|map(.displayName)|index("'"$3"'")' <<< "$USER_JSON" > /dev/null 2>&1
+IS_ADMIN_CODE=$?
+
+if [ $IS_USER_CODE = 1 ] && [ $IS_ADMIN_CODE = 1 ]; then
+    log "User is neither part of user group and admin group"
+    exit 1
+fi
+
+IS_ADMIN=false
+if [ $IS_ADMIN_CODE = 0 ]; then
+    IS_ADMIN=true
 fi
 
 DISPLAY_NAME=$(jq -r '.displayName // .id' <<< $USER_JSON)
@@ -71,11 +91,6 @@ if [[ $? -ne 0 ]]; then
 elif [[ -z "$DISPLAY_NAME" ]]; then
     log "Empty display name not supporter."
     exit 1
-fi
-
-IS_ADMIN=false
-if [[ ! -z "$3" ]] && jq -e '.groups|map(.displayName)|index("'"$3"'")' <<< "$USER_JSON" > /dev/null 2>&1; then
-    IS_ADMIN=true
 fi
 
 IS_LOCAL=false

--- a/example_configs/lldap-ha-auth.sh
+++ b/example_configs/lldap-ha-auth.sh
@@ -65,6 +65,13 @@ if [[ ! -z "$2" ]] && ! jq -e '.groups|map(.displayName)|index("'"$2"'")' <<< $U
 fi
 
 DISPLAY_NAME=$(jq -r '.displayName // .id' <<< $USER_JSON)
+if [[ $? -ne 0 ]]; then
+    log "Failed to parse display name."
+    exit 1
+elif [[ -z "$DISPLAY_NAME" ]]; then
+    log "Empty display name not supporter."
+    exit 1
+fi
 
 IS_ADMIN=false
 if [[ ! -z "$3" ]] && jq -e '.groups|map(.displayName)|index("'"$3"'")' <<< "$USER_JSON" > /dev/null 2>&1; then


### PR DESCRIPTION
Without this, having a user without a display name set try to login
will result in Home Assistant rejecting the login with no error.
LLDAP will correctly return a user,
the command_line auth provider will succeed,
but Home Assitant will still return a 401.

The fix is to set a non empty display name for the user.
But there's no indication for that anywhere.
The logs show nothing obvious.
This is the only log line indicating any error happened:

```text
hass[1444]: 2026-06-22 19:02:56.454 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [133917151886080] Error handling message: Unauthorized (unauthorized)  from 127.0.0.1 (Mozilla/5.0 (X11; Linux x86_...
```

With this change, the command_line auth provider will exit with an error and print:

```text
hass[2220]: Empty display name not supporter.
hass[1434]: 2026-06-22 19:11:30.438 ERROR (MainThread) [homeassistant.auth.providers.command_line] User 'alice' failed to authenticate, command exited with code 1
hass[1434]: 2026-06-22 19:11:30.446 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from localhost (127.0.0.1). Requested URL: '/auth/login_flow/...
```
