### PR TITLE
server: use OsRng for refresh and password-reset tokens

### DIFF
--- a/server/src/sql_tcp_backend_handler.rs
+++ b/server/src/sql_tcp_backend_handler.rs
@@ -15,8 +15,8 @@ use std::collections::HashSet;
 use tracing::{debug, instrument};
 
 fn gen_random_string(len: usize) -> String {
-    use rand::{Rng, SeedableRng, distributions::Alphanumeric, rngs::SmallRng};
-    let mut rng = SmallRng::from_entropy();
+    use rand::{Rng, distributions::Alphanumeric, rngs::OsRng};
+    let mut rng = OsRng;
     std::iter::repeat(())
         .map(|()| rng.sample(Alphanumeric))
         .map(char::from)


### PR DESCRIPTION
`gen_random_string` generates the refresh and password-reset tokens with `SmallRng`, which is not a CSPRNG, while the rest of the codebase uses `OsRng` for secrets. Switch it to `OsRng` to match.

Each call already reseeds from OS entropy, so this is a consistency/hardening change rather than a known practical weakness.
