### PR TITLE
server: Require explicit schema migration for networked DBs by default

### DIFF
--- a/crates/sql-backend-handler/src/sql_tables.rs
+++ b/crates/sql-backend-handler/src/sql_tables.rs
@@ -54,6 +54,52 @@ pub async fn init_table(pool: &DbConnection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Check whether the schema may be migrated automatically on startup, returning
+/// an error with instructions if not.
+///
+/// Migrations run on every startup as an unguarded check-then-apply, so two
+/// instances booting against the same networked database can race and one of
+/// them crashes on the duplicate DDL. To keep multiple instances safe by
+/// default, a networked database (PostgreSQL/MySQL) whose schema is out of date
+/// must be migrated explicitly with the `create_schema` subcommand, unless
+/// auto-migration is turned on. SQLite is single-writer, so it has no race and
+/// migrates automatically.
+///
+/// `auto_migrate`:
+/// - `None`: use the per-backend default (SQLite migrates, networked requires
+///   the explicit step).
+/// - `Some(value)`: force that behavior for any backend.
+///
+/// A database already at the latest version needs no migration and is always
+/// allowed, which is the steady state for every running instance.
+pub async fn check_migration_allowed(
+    pool: &DbConnection,
+    auto_migrate: Option<bool>,
+) -> anyhow::Result<()> {
+    let current_version = get_schema_version(pool).await;
+    // `None` means the schema doesn't exist yet and must be created; a version
+    // below the latest needs an upgrade. A version above the latest is a
+    // downgrade, which `migrate_from_version` rejects later.
+    let needs_migration = match current_version {
+        Some(version) => version < LAST_SCHEMA_VERSION,
+        None => true,
+    };
+    if needs_migration {
+        let is_sqlite = matches!(pool.get_database_backend(), sea_orm::DbBackend::Sqlite);
+        if !auto_migrate.unwrap_or(is_sqlite) {
+            anyhow::bail!(
+                "The database schema needs to be initialized or migrated (current version: {}, \
+required version: {}), but automatic migration on startup is disabled for networked databases \
+to avoid races between multiple instances. Run the `create_schema` subcommand first, then \
+restart; or set LLDAP_AUTO_MIGRATE=true (config key `auto_migrate`) to migrate on startup.",
+                current_version.map_or_else(|| "none".to_owned(), |v| v.0.to_string()),
+                LAST_SCHEMA_VERSION.0,
+            );
+        }
+    }
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum ConfigLocation {
     ConfigFile(String),
@@ -562,5 +608,38 @@ mod tests {
             .await
             .unwrap();
         assert!(init_table(&sql_pool).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_check_migration_allowed_up_to_date_is_always_ok() {
+        crate::logging::init_for_tests();
+        let sql_pool = get_in_memory_db().await;
+        // Bring the DB fully up to date.
+        init_table(&sql_pool).await.unwrap();
+        // A DB already at the latest version needs no migration, so it's allowed
+        // even with auto-migration off: the steady state of a running instance
+        // must not error.
+        check_migration_allowed(&sql_pool, Some(false))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_check_migration_allowed_gates_pending_migration() {
+        crate::logging::init_for_tests();
+        let sql_pool = get_in_memory_db().await;
+        // Out-of-date schema: created at v1, below LAST_SCHEMA_VERSION.
+        upgrade_to_v1(&sql_pool).await.unwrap();
+        // Explicitly disabling auto-migration must refuse to proceed...
+        assert!(
+            check_migration_allowed(&sql_pool, Some(false))
+                .await
+                .is_err()
+        );
+        // ...while enabling it, or relying on the SQLite default (None), is allowed.
+        check_migration_allowed(&sql_pool, Some(true))
+            .await
+            .unwrap();
+        check_migration_allowed(&sql_pool, None).await.unwrap();
     }
 }

--- a/crates/sql-backend-handler/src/sql_tables.rs
+++ b/crates/sql-backend-handler/src/sql_tables.rs
@@ -89,9 +89,10 @@ pub async fn check_migration_allowed(
         if !auto_migrate.unwrap_or(is_sqlite) {
             anyhow::bail!(
                 "The database schema needs to be initialized or migrated (current version: {}, \
-required version: {}), but automatic migration on startup is disabled for networked databases \
-to avoid races between multiple instances. Run the `create_schema` subcommand first, then \
-restart; or set LLDAP_AUTO_MIGRATE=true (config key `auto_migrate`) to migrate on startup.",
+required version: {}), but automatic migration on startup is disabled. Run the `create_schema` \
+subcommand first, then restart; or set LLDAP_AUTO_MIGRATE=true (config key `auto_migrate`) to \
+migrate on startup. (Automatic migration is off by default for networked databases, to avoid \
+races between multiple instances.)",
                 current_version.map_or_else(|| "none".to_owned(), |v| v.0.to_string()),
                 LAST_SCHEMA_VERSION.0,
             );

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -88,6 +88,15 @@
 ## Alternatively, you can set it to "always" to reset every time the server starts.
 # force_ldap_user_pass_reset = false
 
+## Run schema migrations automatically on startup.
+## Defaults to on for SQLite and off for networked databases (PostgreSQL/MySQL):
+## when several instances share one database, running migrations on startup can
+## race, so migrate out of band with the `create_schema` subcommand instead.
+## Set this to true to migrate on startup anyway (e.g. a single instance on a
+## networked database), or false to always require the explicit step.
+## Env variable: LLDAP_AUTO_MIGRATE
+# auto_migrate = true
+
 ## Database URL.
 ## This encodes the type of database (SQlite, MySQL, or PostgreSQL)
 ## , the path, the user, password, and sometimes the mode (when

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -169,6 +169,13 @@ pub struct RunOpts {
     #[clap(long, env = "LLDAP_FORCE_UPDATE_PRIVATE_KEY")]
     pub force_update_private_key: Option<bool>,
 
+    /// Run schema migrations automatically on startup. Defaults to enabled for
+    /// SQLite and disabled for networked databases (PostgreSQL/MySQL), where
+    /// migrations should be run with the `create_schema` subcommand to avoid
+    /// races between multiple instances.
+    #[clap(long, env = "LLDAP_AUTO_MIGRATE")]
+    pub auto_migrate: Option<bool>,
+
     #[clap(flatten)]
     pub smtp_opts: SmtpOpts,
 

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -127,6 +127,11 @@ pub struct Configuration {
     pub force_ldap_user_pass_reset: TrueFalseAlways,
     #[builder(default = "false")]
     pub force_update_private_key: bool,
+    // Whether to run schema migrations automatically on startup. `None` uses the
+    // per-backend default: SQLite migrates, networked databases require the
+    // explicit `create_schema` step. See `check_migration_allowed`.
+    #[builder(default)]
+    pub auto_migrate: Option<bool>,
     #[builder(default = r#"DatabaseUrl::from("sqlite://users.db?mode=rwc")"#)]
     pub database_url: DatabaseUrl,
     #[builder(default)]
@@ -462,6 +467,9 @@ impl ConfigOverrider for RunOpts {
             .inspect(|&force_update_private_key| {
                 config.force_update_private_key = force_update_private_key;
             });
+
+        self.auto_migrate
+            .inspect(|&auto_migrate| config.auto_migrate = Some(auto_migrate));
 
         self.smtp_opts.override_config(config);
         self.ldaps_opts.override_config(config);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -102,7 +102,10 @@ async fn ensure_group_exists(handler: &SqlBackendHandler, group_name: &str) -> R
     Ok(())
 }
 
-async fn setup_sql_tables(database_url: &DatabaseUrl) -> Result<DatabaseConnection> {
+async fn setup_sql_tables(
+    database_url: &DatabaseUrl,
+    auto_migrate: Option<bool>,
+) -> Result<DatabaseConnection> {
     let sql_pool = {
         let num_connections = if database_url.db_type() == "sqlite" {
             1
@@ -116,6 +119,7 @@ async fn setup_sql_tables(database_url: &DatabaseUrl) -> Result<DatabaseConnecti
             .sqlx_logging_level(log::LevelFilter::Debug);
         Database::connect(sql_opt).await?
     };
+    sql_tables::check_migration_allowed(&sql_pool, auto_migrate).await?;
     sql_tables::init_table(&sql_pool)
         .await
         .context("while creating base tables")?;
@@ -129,7 +133,7 @@ async fn setup_sql_tables(database_url: &DatabaseUrl) -> Result<DatabaseConnecti
 async fn set_up_server(config: Configuration) -> Result<(ServerBuilder, DatabaseConnection)> {
     info!("Starting LLDAP version {}", env!("CARGO_PKG_VERSION"));
 
-    let sql_pool = setup_sql_tables(&config.database_url).await?;
+    let sql_pool = setup_sql_tables(&config.database_url, config.auto_migrate).await?;
     let private_key_info = config.get_private_key_info();
     let force_update_private_key = config.force_update_private_key;
     match (
@@ -290,7 +294,8 @@ async fn create_schema_command(opts: RunOpts) -> Result<()> {
     debug!("CLI: {:#?}", &opts);
     let config = configuration::init(opts)?;
     logging::init(&config)?;
-    let sql_pool = setup_sql_tables(&config.database_url).await?;
+    // `create_schema` is the explicit migration entry point, so always migrate.
+    let sql_pool = setup_sql_tables(&config.database_url, Some(true)).await?;
     info!("Schema created successfully.");
     if let Err(e) = sql_pool.close().await {
         error!("Error closing database connection pool: {}", e);


### PR DESCRIPTION
Hey @nitnelave, sorry for the slow turnaround on this, busy weekend. Here's the PR for the migration-safety change we talked through. Let me know if anything needs tweaking and I'll sort it out.

Implements the approach we settled on in #1467.

**Problem.** Migrations run on every startup as an unguarded check-then-apply with no lock. Two instances booting against the same networked database can both try to apply a pending migration — the loser hits duplicate DDL and crash-loops. Running several stateless instances against one Postgres/MySQL is a supported setup, so startup should be safe for it by default.

**Change.** Adds an `auto_migrate` option (env `LLDAP_AUTO_MIGRATE`, config `auto_migrate`). When a migration is pending on startup:

| `auto_migrate` | Behavior |
|---|---|
| unset (default) | SQLite migrates (single-writer, no race); PostgreSQL/MySQL refuse and point at `create_schema` |
| `true` | always migrate on startup |
| `false` | always require the explicit step |

`create_schema` is unchanged and always migrates — it's the explicit entry point. A database already at the latest version is always allowed, so a running deployment is unaffected. Downgrades keep their existing error.

**Heads-up — behavior change on upgrade.** Because the gate fires on any pending migration for a networked DB, a fresh Postgres/MySQL deployment and any single-instance upgrade across a schema bump now need `create_schema` run once (or `LLDAP_AUTO_MIGRATE=true`). This is the safe reading — two instances racing the initial, untransacted `upgrade_to_v1` is the worst case — but it's worth a line in the release notes. Happy to scope it to upgrades-only, or flip the networked default, if you'd rather.

**Tests.** Unit tests for `check_migration_allowed`: an up-to-date DB is allowed even with auto-migration off; a pending migration is refused with `false` and allowed with `true`/unset.

Developed with AI assistance; I've read and understood every line and am happy to walk through or adjust anything.