### PR TITLE
feat(web): manage user and group LDAP object classes

### DIFF
--- a/app/queries/add_group_object_class.graphql
+++ b/app/queries/add_group_object_class.graphql
@@ -1,0 +1,5 @@
+mutation AddGroupObjectClass($name: String!) {
+  addGroupObjectClass(name: $name) {
+    ok
+  }
+}

--- a/app/queries/add_user_object_class.graphql
+++ b/app/queries/add_user_object_class.graphql
@@ -1,0 +1,5 @@
+mutation AddUserObjectClass($name: String!) {
+  addUserObjectClass(name: $name) {
+    ok
+  }
+}

--- a/app/queries/delete_group_object_class.graphql
+++ b/app/queries/delete_group_object_class.graphql
@@ -1,0 +1,5 @@
+mutation DeleteGroupObjectClassQuery($name: String!) {
+  deleteGroupObjectClass(name: $name) {
+    ok
+  }
+}

--- a/app/queries/delete_user_object_class.graphql
+++ b/app/queries/delete_user_object_class.graphql
@@ -1,0 +1,5 @@
+mutation DeleteUserObjectClassQuery($name: String!) {
+  deleteUserObjectClass(name: $name) {
+    ok
+  }
+}

--- a/app/queries/get_group_object_classes.graphql
+++ b/app/queries/get_group_object_classes.graphql
@@ -1,0 +1,10 @@
+query GetGroupObjectClasses {
+  schema {
+    groupSchema {
+      ldapObjectClasses {
+        objectClass
+        isHardcoded
+      }
+    }
+  }
+}

--- a/app/queries/get_user_object_classes.graphql
+++ b/app/queries/get_user_object_classes.graphql
@@ -1,0 +1,10 @@
+query GetUserObjectClasses {
+  schema {
+    userSchema {
+      ldapObjectClasses {
+        objectClass
+        isHardcoded
+      }
+    }
+  }
+}

--- a/app/src/components/add_group_object_class.rs
+++ b/app/src/components/add_group_object_class.rs
@@ -1,0 +1,220 @@
+use crate::{
+    components::{
+        form::{field::Field, submit::Submit},
+        object_class_table::{ObjectClass, ObjectClassTable},
+    },
+    infra::common_component::{CommonComponent, CommonComponentParts},
+};
+use anyhow::{Error, Result, anyhow, bail};
+use graphql_client::GraphQLQuery;
+use validator_derive::Validate;
+use yew::prelude::*;
+use yew_form_derive::Model;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "../schema.graphql",
+    query_path = "queries/add_group_object_class.graphql",
+    response_derives = "Debug",
+    custom_scalars_module = "crate::infra::graphql"
+)]
+pub struct AddGroupObjectClass;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "../schema.graphql",
+    query_path = "queries/get_group_object_classes.graphql",
+    response_derives = "Debug,Clone,PartialEq,Eq",
+    custom_scalars_module = "crate::infra::graphql"
+)]
+pub struct GetGroupObjectClasses;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "../schema.graphql",
+    query_path = "queries/delete_group_object_class.graphql",
+    response_derives = "Debug",
+    custom_scalars_module = "crate::infra::graphql"
+)]
+pub struct DeleteGroupObjectClassQuery;
+
+use add_group_object_class::ResponseData as AddResponseData;
+use delete_group_object_class_query::ResponseData as DeleteResponseData;
+use get_group_object_classes::ResponseData as ListResponseData;
+
+#[derive(Model, Validate, PartialEq, Eq, Clone, Default, Debug)]
+pub struct AddGroupObjectClassModel {
+    #[validate(length(min = 1, message = "object class is required"))]
+    group_object_class: String,
+}
+
+pub enum Msg {
+    Add,
+    AddResponse(Result<AddResponseData>),
+    Delete(String),
+    DeleteResponse(String, Result<DeleteResponseData>),
+    ListResponse(Result<ListResponseData>),
+    Update,
+    OnError(Error),
+}
+
+pub struct ListGroupObjectClass {
+    common: CommonComponentParts<Self>,
+    form: yew_form::Form<AddGroupObjectClassModel>,
+    form_version: usize,
+    object_classes: Option<Vec<ObjectClass>>,
+}
+
+impl CommonComponent<ListGroupObjectClass> for ListGroupObjectClass {
+    fn handle_msg(
+        &mut self,
+        ctx: &Context<Self>,
+        msg: <Self as Component>::Message,
+    ) -> Result<bool> {
+        match msg {
+            Msg::Update => Ok(true),
+            Msg::Add => {
+                let model = self.form.model();
+                if !self.form.validate() {
+                    bail!("A group object class name is required");
+                }
+                self.ensure_object_class_is_new(&model.group_object_class)?;
+                self.common.call_graphql::<AddGroupObjectClass, _>(
+                    ctx,
+                    add_group_object_class::Variables {
+                        name: model.group_object_class,
+                    },
+                    Msg::AddResponse,
+                    "Error trying to add group object class",
+                );
+                Ok(true)
+            }
+            Msg::AddResponse(response) => {
+                response?;
+                self.form = yew_form::Form::new(AddGroupObjectClassModel::default());
+                self.form_version += 1;
+                self.fetch_object_classes(ctx);
+                Ok(true)
+            }
+            Msg::Delete(object_class) => {
+                self.common.call_graphql::<DeleteGroupObjectClassQuery, _>(
+                    ctx,
+                    delete_group_object_class_query::Variables {
+                        name: object_class.clone(),
+                    },
+                    move |response| Msg::DeleteResponse(object_class.clone(), response),
+                    "Error trying to delete group object class",
+                );
+                Ok(true)
+            }
+            Msg::DeleteResponse(object_class, response) => {
+                response?;
+                let object_classes = self
+                    .object_classes
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("object classes have not loaded"))?;
+                object_classes.retain(|class| class.name != object_class);
+                Ok(true)
+            }
+            Msg::ListResponse(response) => {
+                self.object_classes = Some(
+                    response?
+                        .schema
+                        .group_schema
+                        .ldap_object_classes
+                        .into_iter()
+                        .map(|class| ObjectClass {
+                            name: class.object_class,
+                            is_hardcoded: class.is_hardcoded,
+                        })
+                        .collect(),
+                );
+                Ok(true)
+            }
+            Msg::OnError(error) => Err(error),
+        }
+    }
+
+    fn mut_common(&mut self) -> &mut CommonComponentParts<Self> {
+        &mut self.common
+    }
+}
+
+impl Component for ListGroupObjectClass {
+    type Message = Msg;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let mut component = Self {
+            common: CommonComponentParts::<Self>::create(),
+            form: yew_form::Form::new(AddGroupObjectClassModel::default()),
+            form_version: 0,
+            object_classes: None,
+        };
+        component.fetch_object_classes(ctx);
+        component
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        CommonComponentParts::<Self>::update(self, ctx, msg)
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
+        html! {
+            <div>
+                <ObjectClassTable
+                    object_classes={self.object_classes.clone()}
+                    delete_disabled={self.common.is_task_running()}
+                    on_delete={link.callback(Msg::Delete)} />
+                <form class="form py-3" style="max-width: 636px">
+                    <h5 class="fw-bold">{"Add a group object class"}</h5>
+                    <Field<AddGroupObjectClassModel>
+                        key={self.form_version}
+                        label="Name"
+                        required={true}
+                        form={&self.form}
+                        field_name="group_object_class"
+                        oninput={link.callback(|_| Msg::Update)} />
+                    <Submit
+                        disabled={self.common.is_task_running()}
+                        text="Add object class"
+                        onclick={link.callback(|event: MouseEvent| {
+                            event.prevent_default();
+                            Msg::Add
+                        })}/>
+                </form>
+                {self.view_errors()}
+            </div>
+        }
+    }
+}
+
+impl ListGroupObjectClass {
+    fn fetch_object_classes(&mut self, ctx: &Context<Self>) {
+        self.common.call_graphql::<GetGroupObjectClasses, _>(
+            ctx,
+            get_group_object_classes::Variables {},
+            Msg::ListResponse,
+            "Error trying to fetch group object classes",
+        );
+    }
+
+    fn ensure_object_class_is_new(&self, name: &str) -> Result<()> {
+        if self.object_classes.as_ref().is_some_and(|classes| {
+            classes
+                .iter()
+                .any(|class| class.name.eq_ignore_ascii_case(name))
+        }) {
+            bail!("Group object class '{name}' already exists");
+        }
+        Ok(())
+    }
+
+    fn view_errors(&self) -> Html {
+        match &self.common.error {
+            None => html! {},
+            Some(error) => html! {<div class="alert alert-danger">{error.to_string()}</div>},
+        }
+    }
+}

--- a/app/src/components/add_user_object_class.rs
+++ b/app/src/components/add_user_object_class.rs
@@ -1,0 +1,220 @@
+use crate::{
+    components::{
+        form::{field::Field, submit::Submit},
+        object_class_table::{ObjectClass, ObjectClassTable},
+    },
+    infra::common_component::{CommonComponent, CommonComponentParts},
+};
+use anyhow::{Error, Result, anyhow, bail};
+use graphql_client::GraphQLQuery;
+use validator_derive::Validate;
+use yew::prelude::*;
+use yew_form_derive::Model;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "../schema.graphql",
+    query_path = "queries/add_user_object_class.graphql",
+    response_derives = "Debug",
+    custom_scalars_module = "crate::infra::graphql"
+)]
+pub struct AddUserObjectClass;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "../schema.graphql",
+    query_path = "queries/get_user_object_classes.graphql",
+    response_derives = "Debug,Clone,PartialEq,Eq",
+    custom_scalars_module = "crate::infra::graphql"
+)]
+pub struct GetUserObjectClasses;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "../schema.graphql",
+    query_path = "queries/delete_user_object_class.graphql",
+    response_derives = "Debug",
+    custom_scalars_module = "crate::infra::graphql"
+)]
+pub struct DeleteUserObjectClassQuery;
+
+use add_user_object_class::ResponseData as AddResponseData;
+use delete_user_object_class_query::ResponseData as DeleteResponseData;
+use get_user_object_classes::ResponseData as ListResponseData;
+
+#[derive(Model, Validate, PartialEq, Eq, Clone, Default, Debug)]
+pub struct AddUserObjectClassModel {
+    #[validate(length(min = 1, message = "object class is required"))]
+    user_object_class: String,
+}
+
+pub enum Msg {
+    Add,
+    AddResponse(Result<AddResponseData>),
+    Delete(String),
+    DeleteResponse(String, Result<DeleteResponseData>),
+    ListResponse(Result<ListResponseData>),
+    Update,
+    OnError(Error),
+}
+
+pub struct ListUserObjectClass {
+    common: CommonComponentParts<Self>,
+    form: yew_form::Form<AddUserObjectClassModel>,
+    form_version: usize,
+    object_classes: Option<Vec<ObjectClass>>,
+}
+
+impl CommonComponent<ListUserObjectClass> for ListUserObjectClass {
+    fn handle_msg(
+        &mut self,
+        ctx: &Context<Self>,
+        msg: <Self as Component>::Message,
+    ) -> Result<bool> {
+        match msg {
+            Msg::Update => Ok(true),
+            Msg::Add => {
+                let model = self.form.model();
+                if !self.form.validate() {
+                    bail!("A user object class name is required");
+                }
+                self.ensure_object_class_is_new(&model.user_object_class)?;
+                self.common.call_graphql::<AddUserObjectClass, _>(
+                    ctx,
+                    add_user_object_class::Variables {
+                        name: model.user_object_class,
+                    },
+                    Msg::AddResponse,
+                    "Error trying to add user object class",
+                );
+                Ok(true)
+            }
+            Msg::AddResponse(response) => {
+                response?;
+                self.form = yew_form::Form::new(AddUserObjectClassModel::default());
+                self.form_version += 1;
+                self.fetch_object_classes(ctx);
+                Ok(true)
+            }
+            Msg::Delete(object_class) => {
+                self.common.call_graphql::<DeleteUserObjectClassQuery, _>(
+                    ctx,
+                    delete_user_object_class_query::Variables {
+                        name: object_class.clone(),
+                    },
+                    move |response| Msg::DeleteResponse(object_class.clone(), response),
+                    "Error trying to delete user object class",
+                );
+                Ok(true)
+            }
+            Msg::DeleteResponse(object_class, response) => {
+                response?;
+                let object_classes = self
+                    .object_classes
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("object classes have not loaded"))?;
+                object_classes.retain(|class| class.name != object_class);
+                Ok(true)
+            }
+            Msg::ListResponse(response) => {
+                self.object_classes = Some(
+                    response?
+                        .schema
+                        .user_schema
+                        .ldap_object_classes
+                        .into_iter()
+                        .map(|class| ObjectClass {
+                            name: class.object_class,
+                            is_hardcoded: class.is_hardcoded,
+                        })
+                        .collect(),
+                );
+                Ok(true)
+            }
+            Msg::OnError(error) => Err(error),
+        }
+    }
+
+    fn mut_common(&mut self) -> &mut CommonComponentParts<Self> {
+        &mut self.common
+    }
+}
+
+impl Component for ListUserObjectClass {
+    type Message = Msg;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let mut component = Self {
+            common: CommonComponentParts::<Self>::create(),
+            form: yew_form::Form::new(AddUserObjectClassModel::default()),
+            form_version: 0,
+            object_classes: None,
+        };
+        component.fetch_object_classes(ctx);
+        component
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        CommonComponentParts::<Self>::update(self, ctx, msg)
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
+        html! {
+            <div>
+                <ObjectClassTable
+                    object_classes={self.object_classes.clone()}
+                    delete_disabled={self.common.is_task_running()}
+                    on_delete={link.callback(Msg::Delete)} />
+                <form class="form py-3" style="max-width: 636px">
+                    <h5 class="fw-bold">{"Add a user object class"}</h5>
+                    <Field<AddUserObjectClassModel>
+                        key={self.form_version}
+                        label="Name"
+                        required={true}
+                        form={&self.form}
+                        field_name="user_object_class"
+                        oninput={link.callback(|_| Msg::Update)} />
+                    <Submit
+                        disabled={self.common.is_task_running()}
+                        text="Add object class"
+                        onclick={link.callback(|event: MouseEvent| {
+                            event.prevent_default();
+                            Msg::Add
+                        })}/>
+                </form>
+                {self.view_errors()}
+            </div>
+        }
+    }
+}
+
+impl ListUserObjectClass {
+    fn fetch_object_classes(&mut self, ctx: &Context<Self>) {
+        self.common.call_graphql::<GetUserObjectClasses, _>(
+            ctx,
+            get_user_object_classes::Variables {},
+            Msg::ListResponse,
+            "Error trying to fetch user object classes",
+        );
+    }
+
+    fn ensure_object_class_is_new(&self, name: &str) -> Result<()> {
+        if self.object_classes.as_ref().is_some_and(|classes| {
+            classes
+                .iter()
+                .any(|class| class.name.eq_ignore_ascii_case(name))
+        }) {
+            bail!("User object class '{name}' already exists");
+        }
+        Ok(())
+    }
+
+    fn view_errors(&self) -> Html {
+        match &self.common.error {
+            None => html! {},
+            Some(error) => html! {<div class="alert alert-danger">{error.to_string()}</div>},
+        }
+    }
+}

--- a/app/src/components/app.rs
+++ b/app/src/components/app.rs
@@ -10,6 +10,7 @@ use crate::{
         group_schema_table::ListGroupSchema,
         group_table::GroupTable,
         login::LoginForm,
+        object_classes::ObjectClasses,
         reset_password_step1::ResetPasswordStep1Form,
         reset_password_step2::ResetPasswordStep2Form,
         router::{AppRoute, Link, Redirect},
@@ -251,6 +252,9 @@ impl App {
             }
             AppRoute::ListUserSchema => html! {
                 <ListUserSchema />
+            },
+            AppRoute::ObjectClasses => html! {
+                <ObjectClasses />
             },
             AppRoute::ListGroupSchema => html! {
                 <ListGroupSchema />

--- a/app/src/components/banner.rs
+++ b/app/src/components/banner.rs
@@ -53,6 +53,14 @@ pub fn banner(props: &Props) -> Html {
                   <li>
                     <Link
                       classes="nav-link px-2 h6"
+                      to={AppRoute::ObjectClasses}>
+                      <i class="bi-list-ul me-2"></i>
+                      {"Object classes"}
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      classes="nav-link px-2 h6"
                       to={AppRoute::ListGroupSchema}>
                       <i class="bi-list-ul me-2"></i>
                       {"Group schema"}

--- a/app/src/components/mod.rs
+++ b/app/src/components/mod.rs
@@ -1,4 +1,6 @@
 pub mod add_group_member;
+pub mod add_group_object_class;
+pub mod add_user_object_class;
 pub mod add_user_to_group;
 pub mod app;
 pub mod avatar;
@@ -20,6 +22,8 @@ pub mod group_schema_table;
 pub mod group_table;
 pub mod login;
 pub mod logout;
+pub mod object_class_table;
+pub mod object_classes;
 pub mod remove_user_from_group;
 pub mod reset_password_step1;
 pub mod reset_password_step2;

--- a/app/src/components/object_class_table.rs
+++ b/app/src/components/object_class_table.rs
@@ -1,0 +1,71 @@
+use yew::prelude::*;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ObjectClass {
+    pub name: String,
+    pub is_hardcoded: bool,
+}
+
+#[derive(yew::Properties, Clone, PartialEq)]
+pub struct Props {
+    pub object_classes: Option<Vec<ObjectClass>>,
+    pub delete_disabled: bool,
+    pub on_delete: Callback<String>,
+}
+
+#[function_component(ObjectClassTable)]
+pub fn object_class_table(props: &Props) -> Html {
+    let Some(object_classes) = &props.object_classes else {
+        return html! {"Loading..."};
+    };
+
+    let (hardcoded, custom): (Vec<_>, Vec<_>) =
+        object_classes.iter().partition(|class| class.is_hardcoded);
+    html! {
+        <>
+            {view_table(&hardcoded, true, props)}
+            {view_table(&custom, false, props)}
+        </>
+    }
+}
+
+fn view_table(object_classes: &[&ObjectClass], hardcoded: bool, props: &Props) -> Html {
+    html! {
+        <div class="table-responsive">
+            <h3>{if hardcoded {"Hardcoded"} else {"User-defined"}}{" object classes"}</h3>
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>{"Object class"}</th>
+                        {if hardcoded {html! {}} else {html! {<th>{"Delete"}</th>}}}
+                    </tr>
+                </thead>
+                <tbody>
+                    {object_classes.iter().map(|object_class| {
+                        let name = object_class.name.clone();
+                        let on_delete = props.on_delete.clone();
+                        html! {
+                            <tr key={name.clone()}>
+                                <td>{&name}</td>
+                                {if hardcoded {
+                                    html! {}
+                                } else {
+                                    html! {
+                                        <td>
+                                            <button
+                                                class="btn btn-danger"
+                                                disabled={props.delete_disabled}
+                                                onclick={Callback::from(move |_| on_delete.emit(name.clone()))}>
+                                                <i class="bi-x-circle-fill" aria-label="Delete object class" />
+                                            </button>
+                                        </td>
+                                    }
+                                }}
+                            </tr>
+                        }
+                    }).collect::<Html>()}
+                </tbody>
+            </table>
+        </div>
+    }
+}

--- a/app/src/components/object_classes.rs
+++ b/app/src/components/object_classes.rs
@@ -1,0 +1,20 @@
+use crate::components::{
+    add_group_object_class::ListGroupObjectClass, add_user_object_class::ListUserObjectClass,
+};
+use yew::prelude::*;
+
+#[function_component(ObjectClasses)]
+pub fn object_classes() -> Html {
+    html! {
+        <div class="row g-4">
+            <section class="col-12 col-lg-6">
+                <h2>{"User object classes"}</h2>
+                <ListUserObjectClass />
+            </section>
+            <section class="col-12 col-lg-6">
+                <h2>{"Group object classes"}</h2>
+                <ListGroupObjectClass />
+            </section>
+        </div>
+    }
+}

--- a/app/src/components/router.rs
+++ b/app/src/components/router.rs
@@ -26,6 +26,8 @@ pub enum AppRoute {
     ListUserSchema,
     #[at("/user-attributes/create")]
     CreateUserAttribute,
+    #[at("/object-classes")]
+    ObjectClasses,
     #[at("/group-attributes")]
     ListGroupSchema,
     #[at("/group-attributes/create")]


### PR DESCRIPTION
## Summary
- add an administration page for user and group LDAP object classes
- support listing, creating, and deleting custom object classes
- share the object-class table UI across user and group schemas

## Validation
- cargo fmt --all --check
- cargo check -p lldap_app
- cargo test -p lldap_app