### PR TITLE
ldap: Don't return the base object for one-level searches on a leaf

### DIFF
--- a/crates/ldap/src/search.rs
+++ b/crates/ldap/src/search.rs
@@ -28,6 +28,9 @@ enum SearchScope {
     Group(LdapFilter),
     UserOuOnly,
     GroupOuOnly,
+    // The base object is a leaf (a user or a group) and the requested scope only covers its
+    // children, of which it has none.
+    LeafChildren,
     Unknown,
     Invalid,
 }
@@ -36,6 +39,15 @@ enum InternalSearchResults {
     UsersAndGroups(Vec<UserAndGroups>, Vec<Group>),
     Raw(Vec<LdapOp>),
     Empty,
+}
+
+// Whether the scope covers only the entries below the base object, excluding the base object
+// itself. RFC 4511 4.5.1.2 for singleLevel, RFC 3673 for the subordinate subtree.
+fn scope_excludes_base_object(ldap_scope: &LdapSearchScope) -> bool {
+    matches!(
+        ldap_scope,
+        LdapSearchScope::OneLevel | LdapSearchScope::Children
+    )
 }
 
 fn get_search_scope(
@@ -67,17 +79,25 @@ fn get_search_scope(
     } else if dn_parts.len() == base_dn_len + 2
         && dn_parts[1] == ("ou".to_string(), "people".to_string())
     {
-        SearchScope::User(LdapFilter::Equality(
-            dn_parts[0].0.clone(),
-            dn_parts[0].1.clone(),
-        ))
+        if scope_excludes_base_object(ldap_scope) {
+            SearchScope::LeafChildren
+        } else {
+            SearchScope::User(LdapFilter::Equality(
+                dn_parts[0].0.clone(),
+                dn_parts[0].1.clone(),
+            ))
+        }
     } else if dn_parts.len() == base_dn_len + 2
         && dn_parts[1] == ("ou".to_string(), "groups".to_string())
     {
-        SearchScope::Group(LdapFilter::Equality(
-            dn_parts[0].0.clone(),
-            dn_parts[0].1.clone(),
-        ))
+        if scope_excludes_base_object(ldap_scope) {
+            SearchScope::LeafChildren
+        } else {
+            SearchScope::Group(LdapFilter::Equality(
+                dn_parts[0].0.clone(),
+                dn_parts[0].1.clone(),
+            ))
+        }
     } else {
         SearchScope::Unknown
     }
@@ -378,6 +398,7 @@ async fn do_search_internal(
                 }],
             })])
         }
+        SearchScope::LeafChildren => InternalSearchResults::Empty,
         SearchScope::Unknown => {
             warn!(
                 r#"The requested search tree "{}" matches neither the user subtree "ou=people,{}" nor the group subtree "ou=groups,{}""#,
@@ -1498,6 +1519,88 @@ mod tests {
                 message: "".to_string(),
             })
         );
+    }
+
+    #[tokio::test]
+    async fn test_search_one_level_scope_under_user_is_empty() {
+        // A user is a leaf: it has no children, so a singleLevel search based on it must not
+        // return the user itself. The mock has no expectations, so this also checks that we
+        // don't hit the backend at all.
+        let ldap_handler = setup_bound_admin_handler(MockTestBackendHandler::new()).await;
+        let request = LdapSearchRequest {
+            scope: LdapSearchScope::OneLevel,
+            ..make_search_request(
+                "uid=bob,ou=people,dc=example,dc=com",
+                LdapFilter::And(vec![]),
+                vec!["objectClass".to_string()],
+            )
+        };
+        assert_eq!(
+            ldap_handler.do_search_or_dse(&request).await,
+            Ok(vec![make_search_success()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_one_level_scope_under_group_is_empty() {
+        let ldap_handler = setup_bound_admin_handler(MockTestBackendHandler::new()).await;
+        let request = LdapSearchRequest {
+            scope: LdapSearchScope::OneLevel,
+            ..make_search_request(
+                "cn=group_1,ou=groups,dc=example,dc=com",
+                LdapFilter::And(vec![]),
+                vec!["objectClass".to_string()],
+            )
+        };
+        assert_eq!(
+            ldap_handler.do_search_or_dse(&request).await,
+            Ok(vec![make_search_success()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_children_scope_under_user_is_empty() {
+        let ldap_handler = setup_bound_admin_handler(MockTestBackendHandler::new()).await;
+        let request = LdapSearchRequest {
+            scope: LdapSearchScope::Children,
+            ..make_search_request(
+                "uid=bob,ou=people,dc=example,dc=com",
+                LdapFilter::And(vec![]),
+                vec!["objectClass".to_string()],
+            )
+        };
+        assert_eq!(
+            ldap_handler.do_search_or_dse(&request).await,
+            Ok(vec![make_search_success()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_subtree_scope_on_user_returns_the_user() {
+        // The subtree scope includes the base object, so this one must keep working.
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_list_users().returning(|_, _| {
+            Ok(vec![UserAndGroups {
+                user: User {
+                    user_id: UserId::new("bob"),
+                    ..Default::default()
+                },
+                groups: None,
+            }])
+        });
+        let ldap_handler = setup_bound_admin_handler(mock).await;
+        let request = LdapSearchRequest {
+            scope: LdapSearchScope::Subtree,
+            ..make_search_request(
+                "uid=bob,ou=people,dc=example,dc=com",
+                LdapFilter::And(vec![]),
+                vec!["objectClass".to_string()],
+            )
+        };
+        let results = ldap_handler.do_search_or_dse(&request).await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(matches!(results[0], LdapOp::SearchResultEntry(_)));
+        assert!(matches!(results[1], LdapOp::SearchResultDone(_)));
     }
 
     #[tokio::test]

--- a/crates/ldap/src/search.rs
+++ b/crates/ldap/src/search.rs
@@ -1524,8 +1524,8 @@ mod tests {
     #[tokio::test]
     async fn test_search_one_level_scope_under_user_is_empty() {
         // A user is a leaf: it has no children, so a singleLevel search based on it must not
-        // return the user itself. The mock has no expectations, so this also checks that we
-        // don't hit the backend at all.
+        // return the user itself. No list expectation is set on the mock, so this also checks
+        // that we never reach a list operation.
         let ldap_handler = setup_bound_admin_handler(MockTestBackendHandler::new()).await;
         let request = LdapSearchRequest {
             scope: LdapSearchScope::OneLevel,
@@ -1565,6 +1565,23 @@ mod tests {
             scope: LdapSearchScope::Children,
             ..make_search_request(
                 "uid=bob,ou=people,dc=example,dc=com",
+                LdapFilter::And(vec![]),
+                vec!["objectClass".to_string()],
+            )
+        };
+        assert_eq!(
+            ldap_handler.do_search_or_dse(&request).await,
+            Ok(vec![make_search_success()])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_children_scope_under_group_is_empty() {
+        let ldap_handler = setup_bound_admin_handler(MockTestBackendHandler::new()).await;
+        let request = LdapSearchRequest {
+            scope: LdapSearchScope::Children,
+            ..make_search_request(
+                "cn=group_1,ou=groups,dc=example,dc=com",
                 LdapFilter::And(vec![]),
                 vec!["objectClass".to_string()],
             )


### PR DESCRIPTION
Fix #1165.

A one-level search based on a user or group DN returns the base entry itself:

```console
$ ldapsearch -x -H ldap://localhost:3890 -D uid=admin,ou=people,dc=example,dc=com -W \
    -b "uid=admin,ou=people,dc=example,dc=com" -s one "(objectClass=*)" dn
dn: uid=admin,ou=people,dc=example,dc=com
```

RFC 4511 4.5.1.2 says `singleLevel` excludes the base object, so that should return nothing.
Because it doesn't, every user and group is its own child, which is what makes LDAP browsers drill
into a user forever (the screenshots in #1165). It also breaks Keycloak's user deletion: it calls
`listBindings(dn)` and recurses into each child, the child is the same DN, and it dies with a
`StackOverflowError`. Deleting a federated user from the Keycloak console returns 500 until you
delete the user in LLDAP first.

The cause is that `get_search_scope` maps a leaf DN to `SearchScope::User`/`SearchScope::Group`
without looking at the requested scope, so `base`, `one` and `sub` all behave like `base`.

The change: a leaf DN with a scope that excludes the base object (`one`, and `children` from
RFC 3673) resolves to a new `SearchScope::LeafChildren`, which returns no entries. `base` and `sub`
include the base object and are unchanged.

Entries returned by the built binary against a freshly bootstrapped server, before and after:

| search | before | after |
| --- | --- | --- |
| `-b uid=admin,ou=people,…` `-s one` | 1 | 0 |
| `-b uid=admin,ou=people,…` `-s base` | 1 | 1 |
| `-b uid=admin,ou=people,…` `-s sub` | 1 | 1 |
| `-b ou=people,…` `-s one` | 1 | 1 |
| `-b cn=lldap_admin,ou=groups,…` `-s one` | 1 | 0 |
| `-b cn=lldap_admin,ou=groups,…` `-s base` | 1 | 1 |

Three related things I left alone to keep the diff small: a `sub` search on `ou=people` or
`ou=groups` still doesn't return the OU entry itself; a `base` search on the root DN still returns
every user and group; and `one`/`sub` on a *non-existent* leaf DN returns success with no entries
rather than `noSuchObject` (pre-existing, the `noSuchObject` path only covers `base`, and this
change doesn't touch it). Happy to do any of them in a follow-up.

Tests are in `crates/ldap/src/search.rs`: `one` and `children` on a user, `one` and `children` on a
group, and one pinning that `sub` on a user still returns the user. The four leaf tests set no
list expectation on the mock, so they also pin that no list operation is reached. Applied to `main`
without the change to `get_search_scope`, those four fail and the `sub` one passes.

I wrote this with an agent. `cargo test --workspace` (85 in this crate, all green), `cargo fmt
--check` and `cargo clippy -p lldap_ldap --all-targets -- -D warnings` are green locally.
