### PR TITLE
DRAFT: Add unix domain sockets support (UDS)

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -135,6 +135,10 @@ pub struct RunOpts {
     #[clap(long, env = "LLDAP_SERVER_KEY_SEED")]
     pub server_key_seed: Option<String>,
 
+    /// Use ldap unix domain socket instead of ldap_host/ldap_port. Default: None
+    #[clap(long, env = "LLDAP_LDAP_SOCKET")]
+    pub ldap_socket: Option<String>,
+
     /// Change ldap host. Default: "::"
     #[clap(long, env = "LLDAP_LDAP_HOST")]
     pub ldap_host: Option<String>,

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -105,6 +105,8 @@ pub struct HttpUrl(pub Url);
 #[derive(Clone, Deserialize, Serialize, derive_builder::Builder, derive_more::Debug)]
 #[builder(pattern = "owned", build_fn(name = "private_build"))]
 pub struct Configuration {
+    #[builder(default)]
+    pub ldap_socket: Option<String>,
     #[builder(default = r#"String::from("::")"#)]
     pub ldap_host: String,
     #[builder(default = "3890")]
@@ -440,6 +442,10 @@ impl ConfigOverrider for RunOpts {
         self.server_key_seed
             .as_ref()
             .inspect(|seed| config.key_seed = Some(SecUtf8::from(seed.as_str())));
+
+        self.ldap_socket
+            .as_ref()
+            .inspect(|socket| config.ldap_socket = Some(socket.to_string()));
 
         self.ldap_port.inspect(|&port| config.ldap_port = port);
 

--- a/server/src/ldap_server.rs
+++ b/server/src/ldap_server.rs
@@ -1,6 +1,6 @@
 use crate::configuration::{Configuration, LdapsOptions};
 use crate::tls;
-use actix_rt::net::TcpStream;
+use actix_rt::net::{TcpStream, UnixStream};
 use actix_server::ServerBuilder;
 use actix_service::{ServiceFactoryExt, fn_service};
 use anyhow::{Context, Result};
@@ -144,7 +144,28 @@ where
     );
 
     let context_for_tls = context.clone();
+    if let Some(socket) = &config.ldap_socket {
+        // Here is a separate declaration of binder because of concrete type
+        // confusion from the compiler.
+        let binder = move || {
+            let context = context.clone();
+            fn_service(move |stream: UnixStream| {
+                let context = context.clone();
+                async move {
+                    let (handler, ldap_info) = context;
+                    handle_ldap_stream(stream, handler, ldap_info).await
+                }
+            })
+            .map_err(|err: anyhow::Error| error!("[LDAP] Service Error: {:#}", err))
+        };
 
+        info!("Starting the LDAP server on socket {}", socket);
+        return server_builder
+            .bind_uds("ldap", socket, binder)
+            .with_context(|| format!("while binding to socket {}", socket));
+    }
+
+    info!("Starting the LDAP server on port {}", config.ldap_port);
     let binder = move || {
         let context = context.clone();
         fn_service(move |stream: TcpStream| {
@@ -156,8 +177,6 @@ where
         })
         .map_err(|err: anyhow::Error| error!("[LDAP] Service Error: {:#}", err))
     };
-
-    info!("Starting the LDAP server on port {}", config.ldap_port);
     let server_builder = server_builder
         .bind("ldap", (config.ldap_host.clone(), config.ldap_port), binder)
         .with_context(|| format!("while binding to the port {}", config.ldap_port));

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -221,6 +221,7 @@ async fn set_up_server(config: Configuration) -> Result<(ServerBuilder, Database
 }
 
 async fn run_server_command(opts: RunOpts) -> Result<()> {
+    // TODO: this debug is never printed because logging is not initialized yet
     debug!("CLI: {:#?}", &opts);
 
     let config = configuration::init(opts)?;


### PR DESCRIPTION
This is a first draft for #701, to support serving LDAP protocol over unix domain sockets.

In this PR:

- [x] `--ldap-socket` CLI flag / `ldap_socket` configuration flag have precedence over ldap host/port settings ; we could instead support a single `ldap-listen` flag
- [ ] LDAPs over socket is not yet supported
- [ ] HTTP over socket is not yet supported
- [ ] HTTPS over socket is not yet supported (but i think we don't do HTTPS at all in lldap, correct me if i'm wrong)

This is a demo preview so we can gather feedback and make it real.

You can test it with:

```bash
SECRET="$(LC_ALL=C tr -dc 'A-Za-z0-9!#%&'\''()*+,-./:;<=>?@[\]^_{|}~' </dev/urandom | head -c 32; echo '')"
export LLDAP_LDAP_USER_PASS="adminadmin"
export LLDAP_JWT_SECRET="$SECRET"
cargo run -- run --ldap-socket /tmp/lldap.sock --http-port 8080 --database-url sqlite:///tmp/lldap.db?mode=rwc
```

Now you can `ldapwhoami -H ldapi://%2Ftmp%2Flldap.sock -D "cn=admin,ou=people,dc=example,dc=com" -W`